### PR TITLE
Add minimal Dockerfile.base for customizable catnip containers

### DIFF
--- a/container/Dockerfile.base
+++ b/container/Dockerfile.base
@@ -1,0 +1,116 @@
+# Stage 1: Build the frontend
+FROM node:22-alpine AS frontend-builder
+
+WORKDIR /frontend
+
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+
+# Install pnpm and dependencies
+RUN corepack enable && \
+    corepack prepare pnpm@latest --activate && \
+    pnpm install --frozen-lockfile
+
+# Copy frontend source
+COPY . .
+
+# Build frontend
+RUN pnpm build
+
+# Stage 2: Build the Go binary
+FROM golang:1.24 AS builder
+
+WORKDIR /build
+
+# Install basic build tools
+RUN apt-get update && apt-get install -y curl build-essential make wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy go mod files
+COPY container/go.mod container/go.sum ./
+RUN go mod download && \
+    go install github.com/swaggo/swag/cmd/swag@latest
+
+# Copy source code
+COPY container/ .
+
+# Copy built frontend assets for embedding (relative to embedded.go)
+COPY --from=frontend-builder /frontend/dist ./internal/assets/dist
+
+# Install swag and generate swagger documentation, then build the binary
+RUN swag init -g cmd/server/main.go -o docs --parseDependency --parseInternal && \
+    CGO_ENABLED=0 GOOS=linux go build -a -o catnip cmd/server/main.go
+
+# Stage 3: Minimal runtime image
+FROM ubuntu:24.04
+
+# Multi-arch support
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+# Avoid prompts from apt during build
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install only essential packages
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    git \
+    sudo \
+    gosu \
+    locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# Remove default ubuntu user if it exists and create catnip user with UID 1000
+RUN if id ubuntu >/dev/null 2>&1; then userdel -r ubuntu; fi && \
+    useradd -m -s /bin/bash -u 1000 catnip && \
+    usermod -aG sudo catnip && \
+    echo '#1000 ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Create global workspace directory
+RUN mkdir -p /workspace && \
+    chown catnip:catnip /workspace
+
+# Create .ssh directory for catnip user with proper permissions
+RUN mkdir -p /home/catnip/.ssh && \
+    chown catnip:catnip /home/catnip/.ssh && \
+    chmod 700 /home/catnip/.ssh
+
+# Set up global environment variables and PATH
+ENV CATNIP_ROOT="/opt/catnip"
+ENV WORKSPACE="/workspace"
+ENV PATH="${CATNIP_ROOT}/bin:${PATH}"
+
+# Create directory structure
+RUN mkdir -p ${CATNIP_ROOT}/bin ${CATNIP_ROOT}/lib && \
+    chown -R catnip:catnip ${CATNIP_ROOT} && \
+    chmod -R 755 ${CATNIP_ROOT}
+
+# Setup locale
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
+
+# Set minimal git config for catnip user
+USER catnip
+RUN git config --global user.name "catnip" && \
+    git config --global user.email "catnip@catnip.run" && \
+    git config --global init.defaultBranch main && \
+    git config --global --add safe.directory /workspace
+
+# Switch back to root for final setup
+USER root
+
+# Copy the catnip binary from builder stage
+COPY --from=builder /build/catnip ${CATNIP_ROOT}/bin/catnip
+RUN chmod +x ${CATNIP_ROOT}/bin/catnip
+
+# Copy minimal entrypoint script
+COPY container/setup/entrypoint-base.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Set working directory
+WORKDIR /workspace
+
+# Default command
+EXPOSE 8080
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["catnip"]

--- a/container/setup/entrypoint-base.sh
+++ b/container/setup/entrypoint-base.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+# Handle custom username if provided
+if [ -n "$CATNIP_USERNAME" ] && [ "$CATNIP_USERNAME" != "catnip" ]; then
+    # Change the username but keep the same UID and home directory
+    usermod -l "$CATNIP_USERNAME" catnip 2>/dev/null || true
+    # Update the group name too
+    groupmod -n "$CATNIP_USERNAME" catnip 2>/dev/null || true
+    # Unlock the account for SSH (set password to * which allows key auth only)
+    usermod -p '*' "$CATNIP_USERNAME" 2>/dev/null || true
+    # Export for tools
+    export USER="$CATNIP_USERNAME"
+    export USERNAME="$CATNIP_USERNAME"
+fi
+
+# Configure git for the user
+if [ -n "$CATNIP_USERNAME" ]; then
+    GIT_USERNAME="$CATNIP_USERNAME"
+    GIT_EMAIL="${CATNIP_USERNAME}@catnip.run"
+else
+    GIT_USERNAME="catnip"
+    GIT_EMAIL="catnip@catnip.run"
+fi
+
+# Override email if CATNIP_EMAIL is provided
+if [ -n "$CATNIP_EMAIL" ]; then
+    GIT_EMAIL="$CATNIP_EMAIL"
+fi
+
+# Set git config for the catnip user (not root) and mark as safe repo
+gosu 1000:1000 git config --global user.name "$GIT_USERNAME"
+gosu 1000:1000 git config --global user.email "$GIT_EMAIL"
+gosu 1000:1000 git config --global init.defaultBranch main
+gosu 1000:1000 git config --global --add safe.directory /workspace
+
+# Ensure workspace has proper ownership
+chown -R 1000:1000 "${WORKSPACE}" 2>/dev/null || true
+
+# Change to catnip user if running as root
+if [ "$EUID" -eq 0 ]; then
+    # Use gosu for clean user switching without job control issues
+    cd "${WORKSPACE}"
+    # Use the actual username (which might have been changed)
+    ACTUAL_USER=$(id -un 1000 2>/dev/null || echo "catnip")
+    exec gosu "$ACTUAL_USER" "$@"
+fi
+
+# Execute the command
+exec "$@"


### PR DESCRIPTION
This PR introduces a minimal base Docker image for catnip that contains only the essential components required for the application to function.

## Changes
- Created `Dockerfile.base` with only core dependencies: Ubuntu 24.04, catnip binary, essential system packages (curl, git, sudo), and the catnip user setup
- Added `entrypoint-base.sh` with minimal initialization logic for user management and git configuration
- Removed all development tools, language runtimes, and optional features from the base image

## Rationale
The existing Dockerfile includes a comprehensive set of development tools and language runtimes that may not be needed by all users. By providing a minimal base image, users can create custom Dockerfiles that extend from `catnip:base` and add only the tools and dependencies they actually need, resulting in smaller, more focused container images.