### PR TITLE
Add cancellation support for PR content generation

### DIFF
--- a/src/components/PullRequestDialog.tsx
+++ b/src/components/PullRequestDialog.tsx
@@ -545,12 +545,19 @@ Avoid overly lengthy explanations or step-by-step implementation details.`;
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={() => void handleSubmit()} disabled={loading}>
+          <Button
+            onClick={
+              isGenerating ? handleCancelGeneration : () => void handleSubmit()
+            }
+            disabled={loading}
+          >
             {loading ? (
               <>
                 <RefreshCw className="animate-spin h-4 w-4 mr-2" />
                 {isUpdate ? "Updating PR..." : "Creating PR..."}
               </>
+            ) : isGenerating ? (
+              "Cancel Generation"
             ) : isUpdate ? (
               "Update PR"
             ) : (


### PR DESCRIPTION
This PR enhances the Pull Request dialog UX by adding the ability to cancel ongoing AI-generated PR content.

**What changed:** The "Create PR" button now transforms into "Cancel Generation" while Claude is generating the PR title and description. Users can click this button to abort the generation process and immediately proceed with creating the PR using fallback values (either from the existing summary or default templates).

**Why:** Previously, users had to wait for the AI generation to complete before being able to create a PR, even if they decided they didn't want to wait. This change improves the user experience by giving users control over the generation process and allowing them to proceed immediately when needed.

**Implementation notes:** The solution uses an AbortController to properly cancel the fetch request to the Claude API, preventing unnecessary processing and ensuring clean state management. When cancelled, the dialog sets appropriate fallback values and returns the button to its normal "Create PR" state.