### PR TITLE
CLI: native SSH port forwarding with host port collision handling; ba…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- `src/`: React + TypeScript SPA.
+  - `components/` (PascalCase `.tsx`), `routes/` (TanStack Router), `lib/` utilities, `hooks/` (files start with `use-`), `stores/`, `types/`.
+- `worker/`: Cloudflare Worker (entry `worker/index.ts`) and scripts in `worker/scripts/`.
+- `public/`: static assets; `dist/`: build output.
+- `container/`: container build files; `docs/`: documentation; `scripts/`: repo maintenance.
+- Path alias: import from `@/*` (configured in `tsconfig`). Example: `import { cn } from "@/lib/utils"`.
+
+## Build, Test, and Development Commands
+
+- `pnpm dev`: run Vite dev server at `http://localhost:5173`.
+- `pnpm dev:cf:vite`: SPA with Cloudflare dev flag for local Worker integration.
+- `pnpm dev:cf`: build SPA then run `wrangler dev` (Worker + assets); logs are tee’d to `/tmp/wrangler.log`.
+- `pnpm build`: type-check then Vite build to `dist/`.
+- `pnpm preview`: serve built assets locally.
+- `pnpm typecheck` / `pnpm typecheck:worker`: strict TS checks for app/worker.
+- `pnpm lint`: ESLint over repo.
+- `pnpm format:changed`: Prettier on staged/changed files.
+- Containers: `just build-dev` then `just run-dev` for full-stack containerized dev.
+
+## Coding Style & Naming Conventions
+
+- TypeScript strict enabled; prefer explicit types where helpful.
+- ESLint rules in `eslint.config.js`; unused vars allowed with leading `_`.
+- Components: PascalCase filenames and exports. Hooks: `use-*.ts` in `src/hooks`.
+- Imports: prefer `@/*` alias; avoid deep relative chains.
+- Formatting: Prettier is available; use `pnpm format:changed` before commits.
+
+## Testing Guidelines
+
+- No unit test runner is configured yet. Use `pnpm typecheck` and `pnpm lint` as gates.
+- For new tests, prefer colocated files named `*.test.ts(x)` under `src/` and keep fast, isolated modules.
+- Validate end-to-end flows via `pnpm dev:cf` (Worker) or `pnpm dev` (SPA).
+
+## Commit & Pull Request Guidelines
+
+- Commits: short imperative subject with scope prefix when helpful (e.g., `CLI: reannounce host port mappings`, `UI: fix sidebar hostPort`).
+- PRs: include summary, linked issues, screenshots/recordings for UI, and notes on dev/testing steps. Update `docs/` when user-facing behavior changes.
+
+## Security & Configuration Tips
+
+- Secrets: never commit secrets. Use Wrangler secrets (e.g., `wrangler secret put GITHUB_APP_PRIVATE_KEY`).
+- Env: local overrides in `.env.local`; deployment vars are set per-environment in `wrangler.jsonc`.
+- On workspace creation, the container runs `./setup.sh`—install any dependencies there.

--- a/container/docs/docs.go
+++ b/container/docs/docs.go
@@ -1041,6 +1041,99 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/ports/mappings": {
+            "post": {
+                "description": "Records a mapping from container port to host port and broadcasts an SSE event",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ports"
+                ],
+                "summary": "Set host port mapping for a container port",
+                "parameters": [
+                    {
+                        "description": "Mapping object with 'port' and 'host_port'",
+                        "name": "mapping",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Mapping set",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/ports/mappings/{port}": {
+            "delete": {
+                "description": "Removes a mapping and broadcasts an SSE event with host_port=0",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ports"
+                ],
+                "summary": "Delete host port mapping for a container port",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Container port",
+                        "name": "port",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Mapping deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid port",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/ports/{port}": {
             "get": {
                 "description": "Returns detailed information about a specific port if it exists",
@@ -2326,6 +2419,7 @@ const docTemplate = `{
                 "process:started",
                 "process:stopped",
                 "container:status",
+                "port:mapped",
                 "heartbeat",
                 "worktree:status_updated",
                 "worktree:batch_updated",
@@ -2345,6 +2439,7 @@ const docTemplate = `{
                 "ProcessStartedEvent",
                 "ProcessStoppedEvent",
                 "ContainerStatusEvent",
+                "PortMappedEvent",
                 "HeartbeatEvent",
                 "WorktreeStatusUpdatedEvent",
                 "WorktreeBatchUpdatedEvent",

--- a/container/docs/swagger.json
+++ b/container/docs/swagger.json
@@ -1038,6 +1038,99 @@
                 }
             }
         },
+        "/v1/ports/mappings": {
+            "post": {
+                "description": "Records a mapping from container port to host port and broadcasts an SSE event",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ports"
+                ],
+                "summary": "Set host port mapping for a container port",
+                "parameters": [
+                    {
+                        "description": "Mapping object with 'port' and 'host_port'",
+                        "name": "mapping",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Mapping set",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/ports/mappings/{port}": {
+            "delete": {
+                "description": "Removes a mapping and broadcasts an SSE event with host_port=0",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ports"
+                ],
+                "summary": "Delete host port mapping for a container port",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Container port",
+                        "name": "port",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Mapping deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid port",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/ports/{port}": {
             "get": {
                 "description": "Returns detailed information about a specific port if it exists",
@@ -2323,6 +2416,7 @@
                 "process:started",
                 "process:stopped",
                 "container:status",
+                "port:mapped",
                 "heartbeat",
                 "worktree:status_updated",
                 "worktree:batch_updated",
@@ -2342,6 +2436,7 @@
                 "ProcessStartedEvent",
                 "ProcessStoppedEvent",
                 "ContainerStatusEvent",
+                "PortMappedEvent",
                 "HeartbeatEvent",
                 "WorktreeStatusUpdatedEvent",
                 "WorktreeBatchUpdatedEvent",

--- a/container/docs/swagger.yaml
+++ b/container/docs/swagger.yaml
@@ -777,6 +777,7 @@ definitions:
     - process:started
     - process:stopped
     - container:status
+    - port:mapped
     - heartbeat
     - worktree:status_updated
     - worktree:batch_updated
@@ -796,6 +797,7 @@ definitions:
     - ProcessStartedEvent
     - ProcessStoppedEvent
     - ContainerStatusEvent
+    - PortMappedEvent
     - HeartbeatEvent
     - WorktreeStatusUpdatedEvent
     - WorktreeBatchUpdatedEvent
@@ -1701,6 +1703,68 @@ paths:
               type: string
             type: object
       summary: Get port information
+      tags:
+      - ports
+  /v1/ports/mappings:
+    post:
+      consumes:
+      - application/json
+      description: Records a mapping from container port to host port and broadcasts
+        an SSE event
+      parameters:
+      - description: Mapping object with 'port' and 'host_port'
+        in: body
+        name: mapping
+        required: true
+        schema:
+          additionalProperties:
+            type: integer
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Mapping set
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Invalid request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Set host port mapping for a container port
+      tags:
+      - ports
+  /v1/ports/mappings/{port}:
+    delete:
+      consumes:
+      - application/json
+      description: Removes a mapping and broadcasts an SSE event with host_port=0
+      parameters:
+      - description: Container port
+        in: path
+        name: port
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Mapping deleted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Invalid port
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete host port mapping for a container port
       tags:
       - ports
   /v1/pty:

--- a/container/internal/cmd/serve.go
+++ b/container/internal/cmd/serve.go
@@ -175,10 +175,10 @@ func startServer(cmd *cobra.Command) {
 	gitHandler := handlers.NewGitHandler(gitService, gitHTTPService, sessionService, claudeMonitor)
 	claudeHandler := handlers.NewClaudeHandler(claudeService)
 	sessionHandler := handlers.NewSessionsHandler(sessionService, claudeService)
-	portsHandler := handlers.NewPortsHandler(portMonitor)
-	proxyHandler := handlers.NewProxyHandler(portMonitor)
 	eventsHandler := handlers.NewEventsHandler(portMonitor, gitService)
 	defer eventsHandler.Stop()
+	portsHandler := handlers.NewPortsHandler(portMonitor).WithEvents(eventsHandler)
+	proxyHandler := handlers.NewProxyHandler(portMonitor)
 
 	// Connect events handler to GitService for worktree status events
 	gitService.SetEventsHandler(eventsHandler)
@@ -248,6 +248,8 @@ func startServer(cmd *cobra.Command) {
 	// Port monitoring routes
 	v1.Get("/ports", portsHandler.GetPorts)
 	v1.Get("/ports/:port", portsHandler.GetPortInfo)
+	v1.Post("/ports/mappings", portsHandler.SetPortMapping)
+	v1.Delete("/ports/mappings/:port", portsHandler.DeletePortMapping)
 
 	// Server info route
 	v1.Get("/info", func(c *fiber.Ctx) error {

--- a/container/internal/handlers/ports.go
+++ b/container/internal/handlers/ports.go
@@ -8,6 +8,7 @@ import (
 // PortsHandler handles port-related API endpoints
 type PortsHandler struct {
 	monitor *services.PortMonitor
+	events  *EventsHandler
 }
 
 // NewPortsHandler creates a new ports handler
@@ -15,6 +16,12 @@ func NewPortsHandler(monitor *services.PortMonitor) *PortsHandler {
 	return &PortsHandler{
 		monitor: monitor,
 	}
+}
+
+// WithEvents attaches an events handler for broadcasting mapping changes
+func (h *PortsHandler) WithEvents(events *EventsHandler) *PortsHandler {
+	h.events = events
+	return h
 }
 
 // GetPorts returns all detected ports and their service information
@@ -62,4 +69,56 @@ func (h *PortsHandler) GetPortInfo(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
 		"error": "Port not found",
 	})
+}
+
+// SetPortMapping sets or updates a host port mapping for a container port
+// @Summary Set host port mapping for a container port
+// @Description Records a mapping from container port to host port and broadcasts an SSE event
+// @Tags ports
+// @Accept json
+// @Produce json
+// @Param mapping body map[string]int true "Mapping object with 'port' and 'host_port'"
+// @Success 200 {object} map[string]string "Mapping set"
+// @Failure 400 {object} map[string]string "Invalid request"
+// @Router /v1/ports/mappings [post]
+func (h *PortsHandler) SetPortMapping(c *fiber.Ctx) error {
+	if h.events == nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "events handler not configured"})
+	}
+
+	var payload struct {
+		Port     int `json:"port"`
+		HostPort int `json:"host_port"`
+	}
+	if err := c.BodyParser(&payload); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid json"})
+	}
+	if payload.Port <= 0 || payload.HostPort <= 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "port and host_port must be > 0"})
+	}
+
+	h.events.SetPortMapping(payload.Port, payload.HostPort)
+	return c.JSON(fiber.Map{"status": "ok"})
+}
+
+// DeletePortMapping clears a host mapping for a container port
+// @Summary Delete host port mapping for a container port
+// @Description Removes a mapping and broadcasts an SSE event with host_port=0
+// @Tags ports
+// @Accept json
+// @Produce json
+// @Param port path int true "Container port"
+// @Success 200 {object} map[string]string "Mapping deleted"
+// @Failure 400 {object} map[string]string "Invalid port"
+// @Router /v1/ports/mappings/{port} [delete]
+func (h *PortsHandler) DeletePortMapping(c *fiber.Ctx) error {
+	if h.events == nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "events handler not configured"})
+	}
+	port, err := c.ParamsInt("port")
+	if err != nil || port <= 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid port"})
+	}
+	h.events.ClearPortMapping(port)
+	return c.JSON(fiber.Map{"status": "ok"})
 }

--- a/container/internal/tui/app.go
+++ b/container/internal/tui/app.go
@@ -116,8 +116,8 @@ func (a *App) Run(ctx context.Context, workDir string, customPorts []string) (st
 				if pf, ok := payload["port"].(float64); ok {
 					cp := int(pf)
 					a.portForwarder.EnsureForward(cp)
-                    // Immediately announce mapping in case backend restarted
-                    a.portForwarder.ReannounceMappings()
+					// Immediately announce mapping in case backend restarted
+					a.portForwarder.ReannounceMappings()
 				}
 			}
 		case PortClosedEvent:

--- a/container/internal/tui/app.go
+++ b/container/internal/tui/app.go
@@ -116,6 +116,8 @@ func (a *App) Run(ctx context.Context, workDir string, customPorts []string) (st
 				if pf, ok := payload["port"].(float64); ok {
 					cp := int(pf)
 					a.portForwarder.EnsureForward(cp)
+                    // Immediately announce mapping in case backend restarted
+                    a.portForwarder.ReannounceMappings()
 				}
 			}
 		case PortClosedEvent:

--- a/container/internal/tui/app.go
+++ b/container/internal/tui/app.go
@@ -55,6 +55,7 @@ type App struct {
 	containerName    string
 	program          *tea.Program
 	sseClient        *SSEClient
+	portForwarder    *PortForwardManager
 
 	// Initialization parameters
 	containerImage string
@@ -102,6 +103,30 @@ func (a *App) Run(ctx context.Context, workDir string, customPorts []string) (st
 
 	// Initialize SSE client
 	sseClient := NewSSEClient("http://localhost:8080/v1/events", nil)
+	// Initialize port forwarder (uses backend on 8080)
+	a.portForwarder = NewPortForwardManager("http://localhost:8080")
+	// Start forwarding when ports open (only if SSH enabled)
+	sseClient.onEvent = func(ev AppEvent) {
+		if !a.sshEnabled || a.portForwarder == nil {
+			return
+		}
+		switch ev.Type {
+		case PortOpenedEvent:
+			if payload, ok := ev.Payload.(map[string]interface{}); ok {
+				if pf, ok := payload["port"].(float64); ok {
+					cp := int(pf)
+					a.portForwarder.EnsureForward(cp)
+				}
+			}
+		case PortClosedEvent:
+			if payload, ok := ev.Payload.(map[string]interface{}); ok {
+				if pf, ok := payload["port"].(float64); ok {
+					cp := int(pf)
+					a.portForwarder.StopForward(cp)
+				}
+			}
+		}
+	}
 
 	// Create the model - always with initialization
 	m := NewModel(a.containerService, a.containerName, workDir, a.containerImage, a.devMode, a.refreshFlag, customPorts, a.sshEnabled, a.version, a.rmFlag)
@@ -133,6 +158,9 @@ func (a *App) Run(ctx context.Context, workDir string, customPorts []string) (st
 	// Clean up SSE client if it was started
 	if a.sseClient != nil {
 		a.sseClient.Stop()
+	}
+	if a.portForwarder != nil {
+		a.portForwarder.StopAll()
 	}
 
 	// Best-effort terminal reset to avoid leaving the user's terminal in an odd state

--- a/container/internal/tui/port_forwarder.go
+++ b/container/internal/tui/port_forwarder.go
@@ -1,0 +1,290 @@
+package tui
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// PortForwardManager manages SSH port forwarders from host -> container
+// It listens on 127.0.0.1:hostPort and forwards to container localhost:containerPort over SSH.
+type PortForwardManager struct {
+	backendBaseURL string
+
+	sshUser    string
+	sshAddress string // host:port, typically 127.0.0.1:2222
+	keyPath    string // ~/.ssh/catnip_remote
+
+	clientMu sync.Mutex
+	client   *ssh.Client
+
+	forwardsMu sync.Mutex
+	forwards   map[int]*activeForward // containerPort -> forward
+
+	httpClient *http.Client
+}
+
+type activeForward struct {
+	containerPort int
+	hostPort      int
+	listener      net.Listener
+	closed        chan struct{}
+}
+
+func NewPortForwardManager(backendBaseURL string) *PortForwardManager {
+	// Derive ssh parameters
+	user := os.Getenv("USER")
+	if user == "" {
+		user = os.Getenv("USERNAME")
+	}
+	keyPath := filepath.Join(os.Getenv("HOME"), ".ssh", "catnip_remote")
+
+	return &PortForwardManager{
+		backendBaseURL: backendBaseURL,
+		sshUser:        user,
+		sshAddress:     "127.0.0.1:2222",
+		keyPath:        keyPath,
+		forwards:       make(map[int]*activeForward),
+		httpClient:     &http.Client{Timeout: 2 * time.Second},
+	}
+}
+
+// EnsureForward starts a forward for the given container port if not running.
+// Returns the selected hostPort, or 0 on failure.
+func (m *PortForwardManager) EnsureForward(containerPort int) int {
+	m.forwardsMu.Lock()
+	if f, ok := m.forwards[containerPort]; ok {
+		m.forwardsMu.Unlock()
+		return f.hostPort
+	}
+	m.forwardsMu.Unlock()
+
+	// Choose a host port (prefer same number)
+	hostPort := m.findAvailableHostPort(containerPort)
+	if hostPort == 0 {
+		return 0
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", hostPort))
+	if err != nil {
+		return 0
+	}
+
+	fwd := &activeForward{
+		containerPort: containerPort,
+		hostPort:      hostPort,
+		listener:      ln,
+		closed:        make(chan struct{}),
+	}
+
+	m.forwardsMu.Lock()
+	m.forwards[containerPort] = fwd
+	m.forwardsMu.Unlock()
+
+	// Notify backend mapping
+	_ = m.postMapping(containerPort, hostPort)
+
+	go m.acceptLoop(fwd)
+	return hostPort
+}
+
+// StopForward stops forwarding for a container port
+func (m *PortForwardManager) StopForward(containerPort int) {
+	m.forwardsMu.Lock()
+	f, ok := m.forwards[containerPort]
+	if ok {
+		delete(m.forwards, containerPort)
+	}
+	m.forwardsMu.Unlock()
+
+	if ok {
+		_ = f.listener.Close()
+		close(f.closed)
+		_ = m.deleteMapping(containerPort)
+	}
+}
+
+// StopAll stops all active forwards
+func (m *PortForwardManager) StopAll() {
+	m.forwardsMu.Lock()
+	ports := make([]int, 0, len(m.forwards))
+	for p := range m.forwards {
+		ports = append(ports, p)
+	}
+	m.forwardsMu.Unlock()
+	for _, p := range ports {
+		m.StopForward(p)
+	}
+	m.closeSSH()
+}
+
+func (m *PortForwardManager) ensureSSH() (*ssh.Client, error) {
+	m.clientMu.Lock()
+	defer m.clientMu.Unlock()
+	if m.client != nil {
+		return m.client, nil
+	}
+
+	key, err := os.ReadFile(m.keyPath)
+	if err != nil {
+		return nil, err
+	}
+	var signer ssh.Signer
+	if bytes.Contains(key, []byte("BEGIN OPENSSH PRIVATE KEY")) {
+		signer, err = ssh.ParsePrivateKey(key)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Try PEM (PKCS1/PKCS8) for safety
+		block, _ := pem.Decode(key)
+		if block == nil {
+			return nil, fmt.Errorf("failed to parse private key")
+		}
+		parsed, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		signer, err = ssh.NewSignerFromKey(parsed)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// NOTE: We skip host key verification for local dev convenience.
+	// The connection targets 127.0.0.1:2222 within the developer's machine.
+	// Consider configuring known_hosts verification in the future.
+	cfg := &ssh.ClientConfig{
+		User:            m.sshUser,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // Local-only dev convenience (127.0.0.1:2222)
+		Timeout:         5 * time.Second,
+	}
+	client, err := ssh.Dial("tcp", m.sshAddress, cfg)
+	if err != nil {
+		return nil, err
+	}
+	m.client = client
+	return client, nil
+}
+
+func (m *PortForwardManager) closeSSH() {
+	m.clientMu.Lock()
+	defer m.clientMu.Unlock()
+	if m.client != nil {
+		_ = m.client.Close()
+		m.client = nil
+	}
+}
+
+func (m *PortForwardManager) acceptLoop(f *activeForward) {
+	for {
+		conn, err := f.listener.Accept()
+		if err != nil {
+			select {
+			case <-f.closed:
+				return
+			default:
+				// transient error
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+		}
+
+		go func(c net.Conn) {
+			sshClient, err := m.ensureSSH()
+			if err != nil {
+				_ = c.Close()
+				return
+			}
+			remote, err := sshClient.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", f.containerPort))
+			if err != nil {
+				_ = c.Close()
+				// if ssh tunnel failed, reset client to force reconnect next time
+				m.closeSSH()
+				return
+			}
+
+			// bidirectional copy
+			go func() { _, _ = io.Copy(remote, c); _ = remote.Close() }()
+			go func() { _, _ = io.Copy(c, remote); _ = c.Close() }()
+		}(conn)
+	}
+}
+
+func (m *PortForwardManager) findAvailableHostPort(preferred int) int {
+	// try preferred first if not standard reserved
+	if preferred > 0 && preferred != 8080 && preferred != 2222 {
+		if isFreePort(preferred) {
+			return preferred
+		}
+	}
+	// scan fun ranges 3000..9999, then 10000..61000
+	for _, base := range []int{3000, 4000, 5000, 6000, 7000, 8000, 9000} {
+		for off := 0; off < 1000; off++ {
+			p := base + off
+			if p == 8080 || p == 2222 {
+				continue
+			}
+			if isFreePort(p) {
+				return p
+			}
+		}
+	}
+	for p := 10000; p < 61000; p++ {
+		if p == 8080 || p == 2222 {
+			continue
+		}
+		if isFreePort(p) {
+			return p
+		}
+	}
+	return 0
+}
+
+func isFreePort(port int) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+func (m *PortForwardManager) postMapping(containerPort, hostPort int) error {
+	body := fmt.Sprintf(`{"port":%d,"host_port":%d}`, containerPort, hostPort)
+	req, err := http.NewRequest("POST", m.backendBaseURL+"/v1/ports/mappings", bytes.NewBufferString(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (m *PortForwardManager) deleteMapping(containerPort int) error {
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/v1/ports/mappings/%d", m.backendBaseURL, containerPort), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/container/internal/tui/port_forwarder.go
+++ b/container/internal/tui/port_forwarder.go
@@ -147,21 +147,21 @@ func (m *PortForwardManager) StopAll() {
 // ReannounceMappings posts all current containerPort->hostPort mappings to backend.
 // Useful after backend restarts to repopulate in-memory state.
 func (m *PortForwardManager) ReannounceMappings() {
-    m.forwardsMu.Lock()
-    // create snapshot to avoid holding lock during network calls
-    snapshot := make(map[int]int, len(m.forwards))
-    for cport, f := range m.forwards {
-        snapshot[cport] = f.hostPort
-    }
-    m.forwardsMu.Unlock()
+	m.forwardsMu.Lock()
+	// create snapshot to avoid holding lock during network calls
+	snapshot := make(map[int]int, len(m.forwards))
+	for cport, f := range m.forwards {
+		snapshot[cport] = f.hostPort
+	}
+	m.forwardsMu.Unlock()
 
-    for cport, hport := range snapshot {
-        if err := m.postMapping(cport, hport); err != nil {
-            debugLog("PFM: reannounce postMapping failed cport=%d hport=%d err=%v", cport, hport, err)
-        } else {
-            debugLog("PFM: reannounce postMapping ok cport=%d hport=%d", cport, hport)
-        }
-    }
+	for cport, hport := range snapshot {
+		if err := m.postMapping(cport, hport); err != nil {
+			debugLog("PFM: reannounce postMapping failed cport=%d hport=%d err=%v", cport, hport, err)
+		} else {
+			debugLog("PFM: reannounce postMapping ok cport=%d hport=%d", cport, hport)
+		}
+	}
 }
 
 func (m *PortForwardManager) ensureSSH() (*ssh.Client, error) {

--- a/container/internal/tui/port_forwarder.go
+++ b/container/internal/tui/port_forwarder.go
@@ -49,8 +49,8 @@ func NewPortForwardManager(backendBaseURL string) *PortForwardManager {
 	}
 	keyPath := filepath.Join(os.Getenv("HOME"), ".ssh", "catnip_remote")
 
-    debugLog("PFM: init backend=%s", backendBaseURL)
-    return &PortForwardManager{
+	debugLog("PFM: init backend=%s", backendBaseURL)
+	return &PortForwardManager{
 		backendBaseURL: backendBaseURL,
 		sshUser:        user,
 		sshAddress:     "127.0.0.1:2222",
@@ -63,25 +63,25 @@ func NewPortForwardManager(backendBaseURL string) *PortForwardManager {
 // EnsureForward starts a forward for the given container port if not running.
 // Returns the selected hostPort, or 0 on failure.
 func (m *PortForwardManager) EnsureForward(containerPort int) int {
-    debugLog("PFM: EnsureForward containerPort=%d", containerPort)
+	debugLog("PFM: EnsureForward containerPort=%d", containerPort)
 	m.forwardsMu.Lock()
 	if f, ok := m.forwards[containerPort]; ok {
-        debugLog("PFM: already forwarding containerPort=%d hostPort=%d", containerPort, f.hostPort)
+		debugLog("PFM: already forwarding containerPort=%d hostPort=%d", containerPort, f.hostPort)
 		m.forwardsMu.Unlock()
 		return f.hostPort
 	}
 	m.forwardsMu.Unlock()
 
 	// Choose a host port (prefer same number)
-    hostPort := m.findAvailableHostPort(containerPort)
+	hostPort := m.findAvailableHostPort(containerPort)
 	if hostPort == 0 {
-        debugLog("PFM: failed to find available host port for %d", containerPort)
+		debugLog("PFM: failed to find available host port for %d", containerPort)
 		return 0
 	}
 
-    ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", hostPort))
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", hostPort))
 	if err != nil {
-        debugLog("PFM: listen failed hostPort=%d err=%v", hostPort, err)
+		debugLog("PFM: listen failed hostPort=%d err=%v", hostPort, err)
 		return 0
 	}
 
@@ -97,20 +97,20 @@ func (m *PortForwardManager) EnsureForward(containerPort int) int {
 	m.forwardsMu.Unlock()
 
 	// Notify backend mapping
-    if err := m.postMapping(containerPort, hostPort); err != nil {
-        debugLog("PFM: postMapping failed cport=%d hport=%d err=%v", containerPort, hostPort, err)
-    } else {
-        debugLog("PFM: postMapping ok cport=%d hport=%d", containerPort, hostPort)
-    }
+	if err := m.postMapping(containerPort, hostPort); err != nil {
+		debugLog("PFM: postMapping failed cport=%d hport=%d err=%v", containerPort, hostPort, err)
+	} else {
+		debugLog("PFM: postMapping ok cport=%d hport=%d", containerPort, hostPort)
+	}
 
 	go m.acceptLoop(fwd)
-    debugLog("PFM: forwarding started cport=%d -> 127.0.0.1:%d", containerPort, hostPort)
+	debugLog("PFM: forwarding started cport=%d -> 127.0.0.1:%d", containerPort, hostPort)
 	return hostPort
 }
 
 // StopForward stops forwarding for a container port
 func (m *PortForwardManager) StopForward(containerPort int) {
-    debugLog("PFM: StopForward containerPort=%d", containerPort)
+	debugLog("PFM: StopForward containerPort=%d", containerPort)
 	m.forwardsMu.Lock()
 	f, ok := m.forwards[containerPort]
 	if ok {
@@ -118,20 +118,20 @@ func (m *PortForwardManager) StopForward(containerPort int) {
 	}
 	m.forwardsMu.Unlock()
 
-    if ok {
+	if ok {
 		_ = f.listener.Close()
 		close(f.closed)
-        if err := m.deleteMapping(containerPort); err != nil {
-            debugLog("PFM: deleteMapping failed cport=%d err=%v", containerPort, err)
-        } else {
-            debugLog("PFM: deleteMapping ok cport=%d", containerPort)
-        }
+		if err := m.deleteMapping(containerPort); err != nil {
+			debugLog("PFM: deleteMapping failed cport=%d err=%v", containerPort, err)
+		} else {
+			debugLog("PFM: deleteMapping ok cport=%d", containerPort)
+		}
 	}
 }
 
 // StopAll stops all active forwards
 func (m *PortForwardManager) StopAll() {
-    debugLog("PFM: StopAll")
+	debugLog("PFM: StopAll")
 	m.forwardsMu.Lock()
 	ports := make([]int, 0, len(m.forwards))
 	for p := range m.forwards {
@@ -151,10 +151,10 @@ func (m *PortForwardManager) ensureSSH() (*ssh.Client, error) {
 		return m.client, nil
 	}
 
-    debugLog("PFM: ensureSSH user=%s addr=%s key=%s", m.sshUser, m.sshAddress, m.keyPath)
-    key, err := os.ReadFile(m.keyPath)
+	debugLog("PFM: ensureSSH user=%s addr=%s key=%s", m.sshUser, m.sshAddress, m.keyPath)
+	key, err := os.ReadFile(m.keyPath)
 	if err != nil {
-        debugLog("PFM: read key failed: %v", err)
+		debugLog("PFM: read key failed: %v", err)
 		return nil, err
 	}
 	var signer ssh.Signer
@@ -188,13 +188,13 @@ func (m *PortForwardManager) ensureSSH() (*ssh.Client, error) {
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // Local-only dev convenience (127.0.0.1:2222)
 		Timeout:         5 * time.Second,
 	}
-    client, err := ssh.Dial("tcp", m.sshAddress, cfg)
+	client, err := ssh.Dial("tcp", m.sshAddress, cfg)
 	if err != nil {
-        debugLog("PFM: ssh.Dial failed: %v", err)
+		debugLog("PFM: ssh.Dial failed: %v", err)
 		return nil, err
 	}
 	m.client = client
-    debugLog("PFM: ssh connected")
+	debugLog("PFM: ssh connected")
 	return client, nil
 }
 
@@ -208,27 +208,27 @@ func (m *PortForwardManager) closeSSH() {
 }
 
 func (m *PortForwardManager) acceptLoop(f *activeForward) {
-    debugLog("PFM: acceptLoop start cport=%d hport=%d", f.containerPort, f.hostPort)
+	debugLog("PFM: acceptLoop start cport=%d hport=%d", f.containerPort, f.hostPort)
 	for {
 		conn, err := f.listener.Accept()
 		if err != nil {
 			select {
 			case <-f.closed:
-                debugLog("PFM: acceptLoop closed cport=%d", f.containerPort)
+				debugLog("PFM: acceptLoop closed cport=%d", f.containerPort)
 				return
 			default:
 				// transient error
-                debugLog("PFM: accept error: %v", err)
+				debugLog("PFM: accept error: %v", err)
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
 		}
 
 		go func(c net.Conn) {
-            sshClient, err := m.ensureSSH()
+			sshClient, err := m.ensureSSH()
 			if err != nil {
 				_ = c.Close()
-                debugLog("PFM: ensureSSH in conn failed: %v", err)
+				debugLog("PFM: ensureSSH in conn failed: %v", err)
 				return
 			}
 			remote, err := sshClient.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", f.containerPort))
@@ -236,31 +236,31 @@ func (m *PortForwardManager) acceptLoop(f *activeForward) {
 				_ = c.Close()
 				// if ssh tunnel failed, reset client to force reconnect next time
 				m.closeSSH()
-                debugLog("PFM: sshClient.Dial to container failed: %v", err)
+				debugLog("PFM: sshClient.Dial to container failed: %v", err)
 				return
 			}
 
 			// bidirectional copy
-            go func() {
-                _, _ = io.Copy(remote, c)
-                _ = remote.Close()
-                debugLog("PFM: upstream copy done cport=%d", f.containerPort)
-            }()
-            go func() {
-                _, _ = io.Copy(c, remote)
-                _ = c.Close()
-                debugLog("PFM: downstream copy done cport=%d", f.containerPort)
-            }()
+			go func() {
+				_, _ = io.Copy(remote, c)
+				_ = remote.Close()
+				debugLog("PFM: upstream copy done cport=%d", f.containerPort)
+			}()
+			go func() {
+				_, _ = io.Copy(c, remote)
+				_ = c.Close()
+				debugLog("PFM: downstream copy done cport=%d", f.containerPort)
+			}()
 		}(conn)
 	}
 }
 
 func (m *PortForwardManager) findAvailableHostPort(preferred int) int {
-    debugLog("PFM: findAvailableHostPort preferred=%d", preferred)
+	debugLog("PFM: findAvailableHostPort preferred=%d", preferred)
 	// try preferred first if not standard reserved
 	if preferred > 0 && preferred != 8080 && preferred != 2222 {
 		if isFreePort(preferred) {
-            debugLog("PFM: using preferred host port %d", preferred)
+			debugLog("PFM: using preferred host port %d", preferred)
 			return preferred
 		}
 	}
@@ -271,8 +271,8 @@ func (m *PortForwardManager) findAvailableHostPort(preferred int) int {
 			if p == 8080 || p == 2222 {
 				continue
 			}
-            if isFreePort(p) {
-                debugLog("PFM: selected host port %d", p)
+			if isFreePort(p) {
+				debugLog("PFM: selected host port %d", p)
 				return p
 			}
 		}
@@ -281,8 +281,8 @@ func (m *PortForwardManager) findAvailableHostPort(preferred int) int {
 		if p == 8080 || p == 2222 {
 			continue
 		}
-        if isFreePort(p) {
-            debugLog("PFM: selected host port %d", p)
+		if isFreePort(p) {
+			debugLog("PFM: selected host port %d", p)
 			return p
 		}
 	}
@@ -305,12 +305,12 @@ func (m *PortForwardManager) postMapping(containerPort, hostPort int) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-    resp, err := m.httpClient.Do(req)
+	resp, err := m.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-    debugLog("PFM: postMapping response status=%s", resp.Status)
+	debugLog("PFM: postMapping response status=%s", resp.Status)
 	return nil
 }
 
@@ -319,11 +319,11 @@ func (m *PortForwardManager) deleteMapping(containerPort int) error {
 	if err != nil {
 		return err
 	}
-    resp, err := m.httpClient.Do(req)
+	resp, err := m.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-    debugLog("PFM: deleteMapping response status=%s", resp.Status)
+	debugLog("PFM: deleteMapping response status=%s", resp.Status)
 	return nil
 }

--- a/container/internal/tui/port_forwarder.go
+++ b/container/internal/tui/port_forwarder.go
@@ -144,6 +144,26 @@ func (m *PortForwardManager) StopAll() {
 	m.closeSSH()
 }
 
+// ReannounceMappings posts all current containerPort->hostPort mappings to backend.
+// Useful after backend restarts to repopulate in-memory state.
+func (m *PortForwardManager) ReannounceMappings() {
+    m.forwardsMu.Lock()
+    // create snapshot to avoid holding lock during network calls
+    snapshot := make(map[int]int, len(m.forwards))
+    for cport, f := range m.forwards {
+        snapshot[cport] = f.hostPort
+    }
+    m.forwardsMu.Unlock()
+
+    for cport, hport := range snapshot {
+        if err := m.postMapping(cport, hport); err != nil {
+            debugLog("PFM: reannounce postMapping failed cport=%d hport=%d err=%v", cport, hport, err)
+        } else {
+            debugLog("PFM: reannounce postMapping ok cport=%d hport=%d", cport, hport)
+        }
+    }
+}
+
 func (m *PortForwardManager) ensureSSH() (*ssh.Client, error) {
 	m.clientMu.Lock()
 	defer m.clientMu.Unlock()

--- a/container/internal/tui/update.go
+++ b/container/internal/tui/update.go
@@ -414,6 +414,8 @@ func (m Model) handleSSEPortOpened(msg ssePortOpenedMsg) (tea.Model, tea.Cmd) {
 		})
 		debugLog("SSE: Port opened: %d (title: %s)", msg.port, title)
 	}
+	// Attempt to start port forward automatically if SSH is enabled
+	// Forwarding is handled by App-level SSE hook
 	return m, nil
 }
 

--- a/src/components/PortPreview.tsx
+++ b/src/components/PortPreview.tsx
@@ -18,6 +18,8 @@ interface PortPreviewProps {
   onClose: () => void;
 }
 
+import { useAppStore } from "@/stores/appStore";
+
 export function PortPreview({ port, onClose }: PortPreviewProps) {
   const [service, setService] = useState<ServiceInfo | null>(null);
   const [loading, setLoading] = useState(true);
@@ -95,8 +97,14 @@ export function PortPreview({ port, onClose }: PortPreviewProps) {
   };
 
   // Open port in new window
+  const portsMap = useAppStore((s) => s.ports);
+  const hostPort = portsMap.get(port)?.hostPort;
   const openInNewWindow = () => {
-    window.open(`/${port}/`, "_blank");
+    if (hostPort) {
+      window.open(`http://localhost:${hostPort}/`, "_blank");
+    } else {
+      window.open(`/${port}/`, "_blank");
+    }
   };
 
   if (loading) {
@@ -227,7 +235,7 @@ export function PortPreview({ port, onClose }: PortPreviewProps) {
         )}
         <iframe
           ref={iframeRef}
-          src={`/${port}/`}
+          src={hostPort ? `http://localhost:${hostPort}/` : `/${port}/`}
           onLoad={handleIframeLoad}
           onError={handleIframeError}
           className="w-full h-full border-0"

--- a/src/components/PortsDisplay.tsx
+++ b/src/components/PortsDisplay.tsx
@@ -1,30 +1,41 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
-import { Badge } from './ui/badge'
-import { Button } from './ui/button'
-import { ExternalLink, Globe, Server, Eye } from 'lucide-react'
-import { Link } from '@tanstack/react-router'
-import { useAppStore } from '../stores/appStore'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { ExternalLink, Globe, Server, Eye } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { useAppStore } from "../stores/appStore";
 
 export function PortsDisplay() {
-  const { getActivePorts, sseConnected } = useAppStore()
-  const activePorts = getActivePorts()
+  const { getActivePorts, sseConnected } = useAppStore();
+  const activePorts = getActivePorts();
 
   const getServiceIcon = (serviceType: string) => {
     switch (serviceType) {
-      case 'http':
-        return <Globe className="h-4 w-4" />
-      case 'tcp':
-        return <Server className="h-4 w-4" />
+      case "http":
+        return <Globe className="h-4 w-4" />;
+      case "tcp":
+        return <Server className="h-4 w-4" />;
       default:
-        return <Server className="h-4 w-4" />
+        return <Server className="h-4 w-4" />;
     }
-  }
+  };
 
   const openService = (port: number) => {
-    window.open(`/${port}/`, '_blank')
-  }
+    const p = activePorts.find((p) => p.port === port);
+    if (p?.hostPort) {
+      window.open(`http://localhost:${p.hostPort}/`, "_blank");
+    } else {
+      window.open(`/${port}/`, "_blank");
+    }
+  };
 
-  const portCount = activePorts.length
+  const portCount = activePorts.length;
 
   return (
     <Card>
@@ -33,9 +44,7 @@ export function PortsDisplay() {
           <Server className="h-5 w-5" />
           Active Ports
           <Badge variant="secondary">{portCount}</Badge>
-          {!sseConnected && (
-            <Badge variant="destructive">Disconnected</Badge>
-          )}
+          {!sseConnected && <Badge variant="destructive">Disconnected</Badge>}
         </CardTitle>
         <CardDescription>
           Services automatically detected and available for proxy
@@ -44,7 +53,8 @@ export function PortsDisplay() {
       <CardContent>
         {portCount === 0 ? (
           <p className="text-muted-foreground text-center py-8">
-            No active ports detected. Start a service to see it here automatically.
+            No active ports detected. Start a service to see it here
+            automatically.
           </p>
         ) : (
           <div className="space-y-4">
@@ -54,7 +64,7 @@ export function PortsDisplay() {
                 className="flex items-center justify-between p-4 border rounded-lg hover:bg-muted/50 transition-colors"
               >
                 <div className="flex items-center gap-3">
-                  {getServiceIcon(port.service || 'unknown')}
+                  {getServiceIcon(port.service || "unknown")}
                   <div>
                     <div className="font-medium">
                       Port {port.port}
@@ -65,22 +75,24 @@ export function PortsDisplay() {
                       )}
                     </div>
                     <div className="text-sm text-muted-foreground">
-                      {(port.service || 'unknown').toUpperCase()} service
+                      {(port.service || "unknown").toUpperCase()} service
+                      {port.hostPort && (
+                        <span className="ml-2">
+                          • forwarded to localhost:{port.hostPort}
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Badge variant="outline">
-                    {port.service || 'unknown'}
-                  </Badge>
-                  {port.service === 'http' && (
+                  <Badge variant="outline">{port.service || "unknown"}</Badge>
+                  {port.service === "http" && (
                     <div className="flex gap-1">
-                      <Link to="/preview/$port" params={{ port: port.port.toString() }}>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="gap-1"
-                        >
+                      <Link
+                        to="/preview/$port"
+                        params={{ port: port.port.toString() }}
+                      >
+                        <Button size="sm" variant="outline" className="gap-1">
                           <Eye className="h-3 w-3" />
                           Preview
                         </Button>
@@ -103,5 +115,5 @@ export function PortsDisplay() {
         )}
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/src/components/WorkspaceRightSidebar.tsx
+++ b/src/components/WorkspaceRightSidebar.tsx
@@ -575,8 +575,12 @@ function WorkspacePorts({
     );
   }, [allPorts, worktree.path]);
 
-  const openInNewWindow = (port: number) => {
-    window.open(`/${port}/`, "_blank");
+  const openInNewWindow = (p: { port: number; hostPort?: number }) => {
+    if (p.hostPort) {
+      window.open(`http://localhost:${p.hostPort}/`, "_blank");
+    } else {
+      window.open(`/${p.port}/`, "_blank");
+    }
   };
 
   const previewPort = (port: number) => {
@@ -630,9 +634,12 @@ function WorkspacePorts({
                       </Badge>
                     )}
                   </div>
-                  {port.title && (
+                  {(port.title || port.hostPort) && (
                     <p className="text-xs text-muted-foreground truncate">
                       {port.title}
+                      {port.hostPort
+                        ? ` • forwarded to localhost:${port.hostPort}`
+                        : ""}
                     </p>
                   )}
                 </div>
@@ -642,7 +649,7 @@ function WorkspacePorts({
                   className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 hover:opacity-100"
                   onClick={(e) => {
                     e.stopPropagation();
-                    openInNewWindow(port.port);
+                    openInNewWindow(port);
                   }}
                   title="Open in new window"
                 >

--- a/src/components/WorkspaceRightSidebar.tsx
+++ b/src/components/WorkspaceRightSidebar.tsx
@@ -559,14 +559,9 @@ function WorkspacePorts({
   setShowPortPreview: (port: number | null) => void;
   setShowDiffView: (showDiff: boolean) => void;
 }) {
-  // Get ports Map and use size as dependency for stability
-  const portsSize = useAppStore((state) => state.ports.size);
-
-  // Create stable ports array only when size changes
-  const allPorts = useMemo(() => {
-    const state = useAppStore.getState();
-    return Array.from(state.ports.values());
-  }, [portsSize]);
+  // Subscribe to ports Map (reference changes on update), then memoize to array
+  const portsMap = useAppStore((state) => state.ports);
+  const allPorts = useMemo(() => Array.from(portsMap.values()), [portsMap]);
 
   // Filter ports for this workspace
   const workspacePorts = useMemo(() => {
@@ -618,24 +613,30 @@ function WorkspacePorts({
             {workspacePorts.map((port) => (
               <div
                 key={port.port}
-                className={`flex items-center gap-2 p-2 rounded-md hover:bg-muted/50 cursor-pointer group ${
+                className={`flex items-center gap-2 p-2 rounded-md hover:bg-muted/50 cursor-pointer group w-full min-w-0 ${
                   showPortPreview === port.port ? "bg-muted" : ""
                 }`}
                 onClick={() => previewPort(port.port)}
                 title={`Preview port ${port.port} - ${port.title || port.service || "Unknown service"}`}
               >
                 <Globe className="h-3 w-3 text-blue-500 flex-shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium">:{port.port}</span>
+                <div className="flex-1 min-w-0 overflow-hidden">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-sm font-medium flex-shrink-0">
+                      :{port.port}
+                    </span>
                     {port.service && (
-                      <Badge variant="outline" className="text-xs">
+                      <Badge
+                        variant="outline"
+                        className="text-xs max-w-[96px] truncate overflow-hidden"
+                        title={port.service}
+                      >
                         {port.service}
                       </Badge>
                     )}
                   </div>
                   {(port.title || port.hostPort) && (
-                    <p className="text-xs text-muted-foreground truncate">
+                    <p className="text-xs text-muted-foreground truncate whitespace-nowrap max-w-[170px]">
                       {port.title}
                       {port.hostPort
                         ? ` • forwarded to localhost:${port.hostPort}`
@@ -646,7 +647,7 @@ function WorkspacePorts({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 hover:opacity-100"
+                  className="h-6 w-6 p-0 flex-shrink-0 ml-auto"
                   onClick={(e) => {
                     e.stopPropagation();
                     openInNewWindow(port);

--- a/src/routes/preview.$port.tsx
+++ b/src/routes/preview.$port.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useState, useEffect, useRef } from "react";
 import { Loader2 } from "lucide-react";
+import { useAppStore } from "@/stores/appStore";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
 
 export const Route = createFileRoute("/preview/$port")({
@@ -19,6 +20,8 @@ interface ServiceInfo {
 function PreviewComponent() {
   const { port: portParam } = Route.useParams();
   const port = parseInt(portParam, 10);
+  const activePorts = useAppStore((s) => s.getActivePorts());
+  const mapped = activePorts.find((p) => p.port === port)?.hostPort;
   const [service, setService] = useState<ServiceInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -130,7 +133,7 @@ function PreviewComponent() {
     );
   }
 
-  // Removed: allow-same-origin for now...
+  // Prefer host forwarded URL if present
   return (
     <div className="h-[calc(100vh-4rem)] relative">
       {iframeLoading && (
@@ -143,7 +146,7 @@ function PreviewComponent() {
       )}
       <iframe
         ref={iframeRef}
-        src={`/${port}/`}
+        src={mapped ? `http://localhost:${mapped}/` : `/${port}/`}
         onLoad={handleIframeLoad}
         onError={handleIframeError}
         className="w-full border-0"

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -189,6 +189,7 @@ export const useAppStore = create<AppState>()(
 
       switch (event.type) {
         case "port:opened": {
+          console.log("store.handleEvent port:opened", event.payload);
           const newPorts = new Map(ports);
           newPorts.set(event.payload.port, {
             port: event.payload.port,
@@ -200,9 +201,17 @@ export const useAppStore = create<AppState>()(
             hostPort: newPorts.get(event.payload.port)?.hostPort, // preserve mapping if any
           });
           set({ ports: newPorts });
+          console.log(
+            "store.ports updated (opened)",
+            event.payload.port,
+            newPorts.get(event.payload.port),
+            "size=",
+            newPorts.size,
+          );
           break;
         }
         case "port:mapped": {
+          console.log("store.handleEvent port:mapped", event.payload);
           const newPorts = new Map(ports);
           const port = event.payload.port as number;
           const hostPort = event.payload.host_port as number;
@@ -217,6 +226,13 @@ export const useAppStore = create<AppState>()(
             newPorts.set(port, { ...existing, hostPort: undefined });
           }
           set({ ports: newPorts });
+          console.log(
+            "store.ports updated (mapped)",
+            port,
+            newPorts.get(port),
+            "size=",
+            newPorts.size,
+          );
           break;
         }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -189,7 +189,6 @@ export const useAppStore = create<AppState>()(
 
       switch (event.type) {
         case "port:opened": {
-          console.log("store.handleEvent port:opened", event.payload);
           const newPorts = new Map(ports);
           newPorts.set(event.payload.port, {
             port: event.payload.port,
@@ -201,17 +200,9 @@ export const useAppStore = create<AppState>()(
             hostPort: newPorts.get(event.payload.port)?.hostPort, // preserve mapping if any
           });
           set({ ports: newPorts });
-          console.log(
-            "store.ports updated (opened)",
-            event.payload.port,
-            newPorts.get(event.payload.port),
-            "size=",
-            newPorts.size,
-          );
           break;
         }
         case "port:mapped": {
-          console.log("store.handleEvent port:mapped", event.payload);
           const newPorts = new Map(ports);
           const port = event.payload.port as number;
           const hostPort = event.payload.host_port as number;
@@ -226,13 +217,6 @@ export const useAppStore = create<AppState>()(
             newPorts.set(port, { ...existing, hostPort: undefined });
           }
           set({ ports: newPorts });
-          console.log(
-            "store.ports updated (mapped)",
-            port,
-            newPorts.get(port),
-            "size=",
-            newPorts.size,
-          );
           break;
         }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -65,6 +65,14 @@ export interface HeartbeatEvent {
   };
 }
 
+export interface PortMappedEvent {
+  type: "port:mapped";
+  payload: {
+    port: number;
+    host_port: number; // 0 means cleared
+  };
+}
+
 export interface WorktreeStatusUpdatedEvent {
   type: "worktree:status_updated";
   payload: {
@@ -176,6 +184,7 @@ export type AppEvent =
   | ProcessStartedEvent
   | ProcessStoppedEvent
   | ContainerStatusEvent
+  | PortMappedEvent
   | HeartbeatEvent
   | WorktreeStatusUpdatedEvent
   | WorktreeBatchUpdatedEvent


### PR DESCRIPTION
…ckend and UI mapping support

- Add PortForwardManager in CLI TUI to forward container ports to localhost via Go SSH, choosing free host ports and posting mappings
- Backend: new /v1/ports/mappings POST/DELETE and port:mapped SSE; track and broadcast mappings; include on initial SSE connect
- Frontend: handle port:mapped, show forwarded host ports, and prefer host URL in preview/open actions
- Leaves reverse proxy as fallback while improving reliability and UX without brittle path rewriting