### PR TITLE
Add delete functionality to unavailable repository modal

### DIFF
--- a/src/components/WorkspaceLeftSidebar.tsx
+++ b/src/components/WorkspaceLeftSidebar.tsx
@@ -450,7 +450,50 @@ export function WorkspaceLeftSidebar() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogAction>OK</AlertDialogAction>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteWorkspaces}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete Workspaces
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog
+        open={deleteConfirmDialog.open}
+        onOpenChange={(open) =>
+          setDeleteConfirmDialog({ ...deleteConfirmDialog, open })
+        }
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Delete</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete{" "}
+              {deleteConfirmDialog.worktrees.length} workspace
+              {deleteConfirmDialog.worktrees.length > 1 ? "s" : ""} for "
+              {deleteConfirmDialog.repoName}"? This action cannot be undone.
+              {deleteConfirmDialog.worktrees.some(
+                (w) => w.is_dirty || w.commit_count > 0,
+              ) && (
+                <div className="mt-2 text-yellow-600">
+                  Warning: Some workspaces have uncommitted changes or unpushed
+                  commits.
+                </div>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirmed}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete All Workspaces
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
## Summary

Enhanced the "Repository Not Available" modal in the workspace sidebar to include a delete option, allowing users to remove workspaces associated with unavailable repositories directly from the warning dialog.

## Changes

- Added a "Delete Workspaces" button to the unavailable repository modal that triggers a confirmation dialog
- Made the warning icon clickable to open the modal (previously only individual workspaces were clickable)
- Implemented a two-step deletion process with a confirmation dialog that warns users about uncommitted changes or unpushed commits
- Reused the existing `deleteWorktree` logic from `useGitApi` hook to maintain consistency with workspace deletion elsewhere in the app

## Implementation Notes

The delete functionality handles bulk deletion of all workspaces for an unavailable repository and properly navigates away if the current workspace is deleted. The confirmation dialog provides clear warnings about data loss to prevent accidental deletions.