### PR TITLE
Fix session timeout logic to check Claude session log activity

### DIFF
--- a/container/internal/handlers/pty.go
+++ b/container/internal/handlers/pty.go
@@ -855,6 +855,15 @@ func (h *PTYHandler) monitorSession(session *Session) {
 
 		// Use Claude activity-based cleanup logic for Claude sessions
 		if session.Agent == "claude" {
+			// Check Claude session log modification time instead of just connection status
+			claudeLogModTime := h.getClaudeSessionLogModTime(session.WorkDir)
+
+			// If Claude log was modified recently (within 5 minutes), keep session alive
+			if !claudeLogModTime.IsZero() && time.Since(claudeLogModTime) <= 5*time.Minute {
+				log.Printf("🤖 Claude session has recent activity (log modified %v ago), keeping PTY alive: %s", time.Since(claudeLogModTime), session.ID)
+				continue
+			}
+
 			claudeActivityState := h.sessionService.GetClaudeActivityState(session.WorkDir)
 
 			// Cleanup logic based on Claude activity state:
@@ -1316,6 +1325,58 @@ func (h *PTYHandler) monitorClaudeSession(session *Session) {
 			return
 		}
 	}
+}
+
+// getClaudeSessionLogModTime returns the modification time of the most recently modified Claude session log
+func (h *PTYHandler) getClaudeSessionLogModTime(workDir string) time.Time {
+	homeDir := config.Runtime.HomeDir
+
+	// Transform workDir path to Claude projects directory format
+	transformedPath := strings.ReplaceAll(workDir, "/", "-")
+	transformedPath = strings.TrimPrefix(transformedPath, "-")
+	transformedPath = "-" + transformedPath // Add back the leading dash
+
+	claudeProjectsDir := filepath.Join(homeDir, ".claude", "projects", transformedPath)
+
+	// Check if .claude/projects directory exists
+	if _, err := os.Stat(claudeProjectsDir); os.IsNotExist(err) {
+		return time.Time{}
+	}
+
+	files, err := os.ReadDir(claudeProjectsDir)
+	if err != nil {
+		return time.Time{}
+	}
+
+	var newestTime time.Time
+
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".jsonl") {
+			continue
+		}
+
+		// Extract session ID from filename (remove .jsonl extension)
+		sessionID := strings.TrimSuffix(file.Name(), ".jsonl")
+
+		// Validate that it looks like a UUID
+		if len(sessionID) != 36 || strings.Count(sessionID, "-") != 4 {
+			continue
+		}
+
+		// Get file modification time
+		filePath := filepath.Join(claudeProjectsDir, file.Name())
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			continue
+		}
+
+		// Track the newest modification time
+		if fileInfo.ModTime().After(newestTime) {
+			newestTime = fileInfo.ModTime()
+		}
+	}
+
+	return newestTime
 }
 
 // findNewestClaudeSession finds the newest JSONL file in .claude/projects directory


### PR DESCRIPTION
## Summary

Updates the PTY session monitoring logic to prevent premature cleanup of active Claude sessions by checking the modification time of Claude session log files.

## Changes

Previously, the session monitor would terminate PTY sessions based on WebSocket connection status and a simple activity state check. This could lead to sessions being cleaned up while Claude was still actively working, especially when users switched between views or tabs.

This fix adds a new check that looks at the modification time of Claude's session log files (`~/.claude/projects/*/**.jsonl`). If any log file has been modified within the last 5 minutes, the PTY session is kept alive regardless of connection status. This ensures that active Claude sessions won't be terminated while Claude is performing work.

## Implementation

- Added `getClaudeSessionLogModTime()` helper to check the most recent Claude session log modification time
- Updated `monitorSession()` to check log activity before falling back to existing activity state logic
- Maintains a 5-minute buffer from the last log modification to account for processing delays