### PR TITLE
Fix workspace sidebar sorting to prevent reordering on refresh

### DIFF
--- a/container/go.mod
+++ b/container/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
+	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/swag v1.16.6
@@ -75,7 +76,6 @@ require (
 	github.com/pjbgf/sha1cd v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/src/components/WorkspaceLeftSidebar.tsx
+++ b/src/components/WorkspaceLeftSidebar.tsx
@@ -98,7 +98,12 @@ export function WorkspaceLeftSidebar() {
     return Array.from(repoIds)
       .map((repoId) => {
         const repo = getRepository(repoId);
-        return repo ? { ...repo, worktrees: getWorktreesByRepo(repoId) } : null;
+        const worktrees = getWorktreesByRepo(repoId);
+        // Sort worktrees by name in lexical order
+        const sortedWorktrees = worktrees.sort((a, b) =>
+          a.name.localeCompare(b.name),
+        );
+        return repo ? { ...repo, worktrees: sortedWorktrees } : null;
       })
       .filter((repo): repo is NonNullable<typeof repo> => repo !== null)
       .sort((a, b) => {

--- a/src/components/WorkspaceLeftSidebar.tsx
+++ b/src/components/WorkspaceLeftSidebar.tsx
@@ -100,7 +100,13 @@ export function WorkspaceLeftSidebar() {
         const repo = getRepository(repoId);
         return repo ? { ...repo, worktrees: getWorktreesByRepo(repoId) } : null;
       })
-      .filter((repo): repo is NonNullable<typeof repo> => repo !== null);
+      .filter((repo): repo is NonNullable<typeof repo> => repo !== null)
+      .sort((a, b) => {
+        // Sort repositories by name in lexical order
+        const nameA = a.name || a.id;
+        const nameB = b.name || b.id;
+        return nameA.localeCompare(nameB);
+      });
   }, [worktreesCount, worktrees, getWorktreesByRepo, getRepository]);
 
   // Find current worktree to get its repo_id for expanded state


### PR DESCRIPTION
## Summary

Fixed an issue where repositories and workspaces in the left sidebar would reorder randomly on page refresh, causing a "bouncing" effect that disrupted the user experience.

## Changes

- Added lexical sorting for repositories by name (or ID as fallback)
- Added lexical sorting for workspaces within each repository by name
- Ensures consistent, stable ordering across page refreshes and state updates

The sorting is applied in the `repositoriesWithWorktrees` memoized computation to maintain performance while providing predictable ordering.