### PR TITLE
Fix incorrect log levels for status and error messages

### DIFF
--- a/container/internal/handlers/pty.go
+++ b/container/internal/handlers/pty.go
@@ -242,7 +242,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 	// Get or create session
 	session := h.getOrCreateSession(sessionID, agent, reset)
 	if session == nil {
-		logger.Infof("❌ Failed to create session: %s", sessionID)
+		logger.Errorf("❌ Failed to create session: %s", sessionID)
 
 		// Send error message to client before closing
 		errorMsg := struct {
@@ -335,7 +335,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 	defer func() {
 		// Recover from any panics in this connection handler
 		if r := recover(); r != nil {
-			logger.Infof("❌ Recovered from panic in PTY connection handler: %v", r)
+			logger.Errorf("❌ Recovered from panic in PTY connection handler: %v", r)
 		}
 
 		close(done) // Signal goroutines to stop
@@ -394,7 +394,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 
 		// Safe close with error handling
 		if err := conn.Close(); err != nil {
-			logger.Infof("❌ Error closing websocket connection: %v", err)
+			logger.Warnf("❌ Error closing websocket connection: %v", err)
 		}
 	}()
 
@@ -402,7 +402,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				logger.Infof("❌ Recovered from panic in PTY read goroutine: %v", r)
+				logger.Errorf("❌ Recovered from panic in PTY read goroutine: %v", r)
 			}
 		}()
 
@@ -441,7 +441,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 					// Continue reading from new PTY
 					continue
 				}
-				logger.Infof("❌ PTY read error: %v", err)
+				logger.Errorf("❌ PTY read error: %v", err)
 				return
 			}
 
@@ -492,7 +492,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 	for {
 		messageType, data, err := conn.ReadMessage()
 		if err != nil {
-			logger.Infof("❌ WebSocket read error: %v", err)
+			logger.Errorf("❌ WebSocket read error: %v", err)
 			break
 		}
 
@@ -554,7 +554,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 						session.bufferMutex.RUnlock()
 
 						if err := session.writeToConnection(conn, websocket.BinaryMessage, bufferToReplay); err != nil {
-							logger.Infof("❌ Failed to replay buffer: %v", err)
+							logger.Warnf("❌ Failed to replay buffer: %v", err)
 						}
 
 						// If we filtered TUI content, send a refresh signal to trigger TUI repaint
@@ -563,7 +563,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 								time.Sleep(100 * time.Millisecond)
 								logger.Infof("🔄 Sending Ctrl+L to refresh TUI after filtered buffer replay")
 								if _, err := session.PTY.Write([]byte("\x0c")); err != nil {
-									logger.Infof("❌ Failed to send refresh signal: %v", err)
+									logger.Warnf("❌ Failed to send refresh signal: %v", err)
 								}
 							}()
 						}
@@ -586,7 +586,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 					if controlMsg.Data != "" {
 						logger.Infof("📝 Injecting prompt into PTY: %q (submit: %v)", controlMsg.Data, controlMsg.Submit)
 						if _, err := session.PTY.Write([]byte(controlMsg.Data)); err != nil {
-							logger.Infof("❌ Failed to write prompt to PTY: %v", err)
+							logger.Warnf("❌ Failed to write prompt to PTY: %v", err)
 						}
 
 						// If submit is true, send a carriage return after a small delay
@@ -597,7 +597,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 								time.Sleep(100 * time.Millisecond)
 								logger.Infof("↩️ Sending carriage return (\\r) to execute prompt")
 								if _, err := session.PTY.Write([]byte("\r")); err != nil {
-									logger.Infof("❌ Failed to write carriage return to PTY: %v", err)
+									logger.Warnf("❌ Failed to write carriage return to PTY: %v", err)
 								}
 							}()
 						}
@@ -649,7 +649,7 @@ func (h *PTYHandler) handlePTYConnection(conn *websocket.Conn, sessionID, agent 
 
 		// Write data to PTY (only from write-enabled connections)
 		if _, err := session.PTY.Write(data); err != nil {
-			logger.Infof("❌ PTY write error: %v", err)
+			logger.Errorf("❌ PTY write error: %v", err)
 			break
 		}
 
@@ -708,11 +708,11 @@ func (h *PTYHandler) getOrCreateSession(sessionID, agent string, reset bool) *Se
 				workDir = target
 				logger.Infof("📁 Using current workspace symlink for default session: %s", workDir)
 			} else {
-				logger.Infof("❌ Current workspace symlink target is invalid: %s", target)
+				logger.Errorf("❌ Current workspace symlink target is invalid: %s", target)
 				return nil
 			}
 		} else {
-			logger.Infof("❌ Default session requested but current symlink does not exist at %s", currentSymlinkPath)
+			logger.Errorf("❌ Default session requested but current symlink does not exist at %s", currentSymlinkPath)
 			return nil
 		}
 	} else if strings.Contains(baseSessionID, "/") {
@@ -730,17 +730,17 @@ func (h *PTYHandler) getOrCreateSession(sessionID, agent string, reset bool) *Se
 					workDir = branchWorktreePath
 					logger.Debugf("📁 Using Git worktree for session %s: %s", baseSessionID, workDir)
 				} else {
-					logger.Infof("❌ Directory exists but is not a valid git worktree: %s", branchWorktreePath)
-					logger.Infof("❌ CRITICAL: Refusing to create PTY session for non-existent worktree to prevent opening wrong directory")
+					logger.Errorf("❌ Directory exists but is not a valid git worktree: %s", branchWorktreePath)
+					logger.Errorf("❌ CRITICAL: Refusing to create PTY session for non-existent worktree to prevent opening wrong directory")
 					return nil
 				}
 			} else {
-				logger.Infof("❌ Worktree directory does not exist: %s", branchWorktreePath)
+				logger.Errorf("❌ Worktree directory does not exist: %s", branchWorktreePath)
 				logger.Infof("❌ CRITICAL: Refusing to create PTY session for non-existent worktree to prevent opening wrong directory")
 				return nil
 			}
 		} else {
-			logger.Infof("❌ Invalid session format: %s", baseSessionID)
+			logger.Errorf("❌ Invalid session format: %s", baseSessionID)
 			return nil
 		}
 	} else {
@@ -750,15 +750,15 @@ func (h *PTYHandler) getOrCreateSession(sessionID, agent string, reset bool) *Se
 			workDir = sessionWorkDir
 			logger.Infof("📁 Using existing workspace directory: %s", workDir)
 		} else {
-			logger.Infof("❌ Workspace directory does not exist: %s", sessionWorkDir)
-			logger.Infof("❌ CRITICAL: Refusing to create PTY session for non-existent workspace to prevent opening wrong directory")
+			logger.Errorf("❌ Workspace directory does not exist: %s", sessionWorkDir)
+			logger.Errorf("❌ CRITICAL: Refusing to create PTY session for non-existent workspace to prevent opening wrong directory")
 			return nil
 		}
 	}
 
 	// workDir should be set at this point or we would have returned nil
 	if workDir == "" {
-		logger.Infof("❌ Failed to determine valid workspace directory for session: %s", baseSessionID)
+		logger.Errorf("❌ Failed to determine valid workspace directory for session: %s", baseSessionID)
 		return nil
 	}
 
@@ -776,7 +776,7 @@ func (h *PTYHandler) getOrCreateSession(sessionID, agent string, reset bool) *Se
 	// Allocate ports for this session
 	ports, err := h.portService.AllocatePortsForSession(sessionID)
 	if err != nil {
-		logger.Infof("❌ Failed to allocate ports for session %s: %v", sessionID, err)
+		logger.Errorf("❌ Failed to allocate ports for session %s: %v", sessionID, err)
 		return nil
 	}
 	logger.Debugf("🔗 Allocated ports for session %s: PORT=%d, PORTZ=%v", sessionID, ports.PORT, ports.PORTZ)
@@ -789,7 +789,7 @@ func (h *PTYHandler) getOrCreateSession(sessionID, agent string, reset bool) *Se
 	// Start PTY for all session types including setup
 	ptmx, err = pty.Start(cmd)
 	if err != nil {
-		logger.Infof("❌ Failed to start PTY: %v", err)
+		logger.Errorf("❌ Failed to start PTY: %v", err)
 		return nil
 	}
 	// Set initial size
@@ -1076,7 +1076,7 @@ func (h *PTYHandler) recreateSession(session *Session) {
 		var err error
 		ports, err = h.portService.AllocatePortsForSession(session.ID)
 		if err != nil {
-			logger.Infof("❌ Failed to allocate ports for session %s during recreation: %v", session.ID, err)
+			logger.Errorf("❌ Failed to allocate ports for session %s during recreation: %v", session.ID, err)
 			return
 		}
 	}
@@ -1087,7 +1087,7 @@ func (h *PTYHandler) recreateSession(session *Session) {
 	// Start new PTY
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
-		logger.Infof("❌ Failed to recreate PTY: %v", err)
+		logger.Errorf("❌ Failed to recreate PTY: %v", err)
 		return
 	}
 
@@ -1273,7 +1273,7 @@ func (s *Session) broadcastToConnections(messageType int, data []byte) {
 
 	for conn, connInfo := range s.connections {
 		if err := conn.WriteMessage(messageType, data); err != nil {
-			logger.Infof("❌ WebSocket write error for connection [%s] in session %s: %v", connInfo.ConnID, s.ID, err)
+			logger.Warnf("❌ WebSocket write error for connection [%s] in session %s: %v", connInfo.ConnID, s.ID, err)
 			// Mark connection for removal
 			disconnectedConns = append(disconnectedConns, conn)
 		}
@@ -1562,7 +1562,7 @@ func (h *PTYHandler) promoteConnection(session *Session, requestingConn *websock
 
 	requestingConnInfo, exists := session.connections[requestingConn]
 	if !exists {
-		logger.Infof("❌ Requesting connection not found in session connections")
+		logger.Warnf("❌ Requesting connection not found in session connections")
 		return
 	}
 
@@ -1656,7 +1656,7 @@ func (h *PTYHandler) handleFocusChange(session *Session, conn *websocket.Conn, f
 
 	connInfo, exists := session.connections[conn]
 	if !exists {
-		logger.Infof("❌ Connection not found in session connections for focus change")
+		logger.Warnf("❌ Connection not found in session connections for focus change")
 		return
 	}
 

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -1096,7 +1096,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 	logger.Warnf("🧹 Starting cleanup of merged worktrees, checking %d worktrees", len(s.stateManager.GetAllWorktrees()))
 
 	for _, worktree := range s.stateManager.GetAllWorktrees() {
-		logger.Warnf("🔍 Checking worktree %s: dirty=%v, conflicts=%v, commits_ahead=%d, source=%s",
+		logger.Debugf("🔍 Checking worktree %s: dirty=%v, conflicts=%v, commits_ahead=%d, source=%s",
 			worktree.Name, worktree.IsDirty, worktree.HasConflicts, worktree.CommitCount, worktree.SourceBranch)
 
 		// Skip if worktree has uncommitted changes or conflicts
@@ -1126,7 +1126,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 		var isMerged bool
 
 		if isLocal {
-			logger.Warnf("🔍 Checking local worktree %s: branch=%s, source=%s", worktree.Name, worktree.Branch, worktree.SourceBranch)
+			logger.Debugf("🔍 Checking local worktree %s: branch=%s, source=%s", worktree.Name, worktree.Branch, worktree.SourceBranch)
 
 			// For local repos, check if the branch exists in the main repo
 			// If it doesn't exist, it was likely deleted after merge
@@ -1154,7 +1154,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 			}
 		} else {
 			// Regular repo logic (existing code)
-			logger.Warnf("🔍 Checking if branch %s is merged into %s in repo %s", worktree.Branch, worktree.SourceBranch, repo.Path)
+			logger.Debugf("🔍 Checking if branch %s is merged into %s in repo %s", worktree.Branch, worktree.SourceBranch, repo.Path)
 			branches, err := s.operations.ListBranches(repo.Path, git.ListBranchesOptions{Merged: worktree.SourceBranch})
 			if err != nil {
 				logger.Warnf("⚠️ Failed to check merged status for %s: %v", worktree.Name, err)
@@ -1451,7 +1451,7 @@ func (s *GitService) CreateWorktreePreview(worktreeID string) error {
 	}
 
 	previewBranchName := fmt.Sprintf("catnip/%s", git.ExtractWorkspaceName(worktree.Branch))
-	logger.Warnf("🔍 Creating preview branch %s for worktree %s", previewBranchName, worktree.Name)
+	logger.Debugf("🔍 Creating preview branch %s for worktree %s", previewBranchName, worktree.Name)
 
 	// Check if there are uncommitted changes (staged, unstaged, or untracked)
 	hasUncommittedChanges, err := s.hasUncommittedChanges(worktree.Path)
@@ -2027,7 +2027,7 @@ func (s *GitService) ensureBaseBranchOnRemote(worktree *models.Worktree, repo *m
 func (s *GitService) checkBaseBranchOnRemote(worktree *models.Worktree, remoteURL string) error {
 	// Convert SSH URLs to HTTPS to avoid authentication issues
 	httpsURL := git.ConvertSSHToHTTPS(remoteURL)
-	logger.Warnf("🔍 Checking base branch on remote: %s -> %s", remoteURL, httpsURL)
+	logger.Debugf("🔍 Checking base branch on remote: %s -> %s", remoteURL, httpsURL)
 
 	// Use git ls-remote to check if the base branch exists on remote
 	output, err := s.runGitCommand("", "ls-remote", "--heads", httpsURL, worktree.SourceBranch)
@@ -2418,7 +2418,7 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 			parts := strings.Split(worktree.Name, "/")
 			workspaceName := parts[len(parts)-1]
 			branchRef = fmt.Sprintf("refs/catnip/%s", workspaceName)
-			logger.Warnf("🔍 Using catnip ref %s for recreating renamed worktree %s", branchRef, worktree.Name)
+			logger.Debugf("🔍 Using catnip ref %s for recreating renamed worktree %s", branchRef, worktree.Name)
 		}
 
 		// Use existing CreateWorktree logic
@@ -2482,14 +2482,14 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 			logger.Warnf("⚠️ Failed to get current branch for renamed worktree %s: %v", worktree.Name, err)
 		} else {
 			currentBranch := strings.TrimSpace(string(currentBranchOutput))
-			logger.Warnf("🔍 Current branch: %s", currentBranch)
+			logger.Debugf("🔍 Current branch: %s", currentBranch)
 
 			// Look up the nice branch name from git config
 			configKey := fmt.Sprintf("catnip.branch-map.%s", strings.ReplaceAll(currentBranch, "/", "."))
 			niceBranchName, err := s.operations.GetConfig(worktree.Path, configKey)
 			if err == nil && strings.TrimSpace(niceBranchName) != "" {
 				niceBranchName = strings.TrimSpace(niceBranchName)
-				logger.Warnf("🔍 Found nice branch mapping: %s -> %s", currentBranch, niceBranchName)
+				logger.Debugf("🔍 Found nice branch mapping: %s -> %s", currentBranch, niceBranchName)
 
 				// Get current commit hash
 				currentCommit, err := s.operations.GetCommitHash(worktree.Path, "HEAD")

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -597,7 +597,7 @@ func (s *GitService) handleExistingRepository(repoID, repoURL, barePath, branch 
 	}
 
 	// State persistence handled by state manager
-	logger.Warnf("✅ Worktree created from existing repository: %s", repoID)
+	logger.Infof("✅ Worktree created from existing repository: %s", repoID)
 	return repo, worktree, nil
 }
 
@@ -648,7 +648,7 @@ func (s *GitService) cloneNewRepository(repoID, repoURL, barePath, branch string
 	}
 
 	// State persistence handled by state manager
-	logger.Warnf("✅ Repository cloned successfully: %s", repository.ID)
+	logger.Infof("✅ Repository cloned successfully: %s", repository.ID)
 	return repository, worktree, nil
 }
 
@@ -741,7 +741,7 @@ func (s *GitService) configureGitCredentials() {
 	if err := s.githubManager.ConfigureGitCredentials(); err != nil {
 		logger.Warnf("❌ Failed to configure Git credential helper: %v", err)
 	} else {
-		logger.Warnf("✅ Git credential helper configured successfully")
+		logger.Infof("✅ Git credential helper configured successfully")
 	}
 }
 
@@ -821,7 +821,7 @@ func (s *GitService) detectLocalRepos() {
 			if _, worktree, err := s.handleLocalRepoWorktree(repoID, repo.DefaultBranch); err != nil {
 				logger.Warnf("❌ Failed to create initial worktree for %s: %v", repoID, err)
 			} else {
-				logger.Warnf("✅ Initial worktree created: %s", worktree.Name)
+				logger.Infof("✅ Initial worktree created: %s", worktree.Name)
 			}
 		}
 	}
@@ -905,7 +905,7 @@ func (s *GitService) handleLocalRepoWorktree(repoID, branch string) (*models.Rep
 	// Save state
 	// State persistence handled by state manager
 
-	logger.Warnf("✅ Local repo worktree created: %s from branch %s", worktree.Name, worktree.SourceBranch)
+	logger.Infof("✅ Local repo worktree created: %s from branch %s", worktree.Name, worktree.SourceBranch)
 	return localRepo, worktree, nil
 }
 
@@ -1080,7 +1080,7 @@ func (s *GitService) UpdateWorktreeBranchName(worktreePath, newBranchName string
 		return fmt.Errorf("failed to update worktree branch: %v", err)
 	}
 
-	logger.Warnf("✅ Updated worktree %s branch name: %s -> %s", targetWorktree.Name, oldBranchName, newBranchName)
+	logger.Infof("✅ Updated worktree %s branch name: %s -> %s", targetWorktree.Name, oldBranchName, newBranchName)
 
 	return nil
 }
@@ -1133,7 +1133,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 			branchExists := s.operations.BranchExists(repo.Path, worktree.Branch, false)
 
 			if !branchExists {
-				logger.Warnf("✅ Branch %s no longer exists in main repo (likely merged and deleted)", worktree.Branch)
+				logger.Infof("✅ Branch %s no longer exists in main repo (likely merged and deleted)", worktree.Branch)
 				isMerged = true
 			} else {
 				// Branch still exists, check if it's merged
@@ -1147,7 +1147,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 					branch = git.CleanBranchName(branch)
 					if branch == worktree.Branch {
 						isMerged = true
-						logger.Warnf("✅ Found %s in merged branches list", worktree.Branch)
+						logger.Infof("✅ Found %s in merged branches list", worktree.Branch)
 						break
 					}
 				}
@@ -1169,7 +1169,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 				branch = git.CleanBranchName(branch)
 				if branch == worktree.Branch {
 					isMerged = true
-					logger.Warnf("✅ Found %s in merged branches list", worktree.Branch)
+					logger.Infof("✅ Found %s in merged branches list", worktree.Branch)
 					break
 				}
 			}
@@ -1194,7 +1194,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 	}
 
 	if len(cleanedUp) > 0 {
-		logger.Warnf("✅ Cleaned up %d merged worktrees: %s", len(cleanedUp), strings.Join(cleanedUp, ", "))
+		logger.Infof("✅ Cleaned up %d merged worktrees: %s", len(cleanedUp), strings.Join(cleanedUp, ", "))
 	}
 
 	if len(errors) > 0 {
@@ -1213,7 +1213,7 @@ func (s *GitService) cleanupActiveSessions(worktreePath string) {
 		// Don't log this as an error since it's common for no processes to be found
 		logger.Warnf("ℹ️ No active processes found for worktree path: %s", worktreePath)
 	} else {
-		logger.Warnf("✅ Terminated processes for worktree: %s", worktreePath)
+		logger.Infof("✅ Terminated processes for worktree: %s", worktreePath)
 	}
 
 	// Also try to cleanup any session directories that might exist
@@ -1229,7 +1229,7 @@ func (s *GitService) cleanupActiveSessions(worktreePath string) {
 				if removeErr := os.RemoveAll(sessionWorkDir); removeErr != nil {
 					logger.Warnf("⚠️ Failed to remove session directory %s: %v", sessionWorkDir, removeErr)
 				} else {
-					logger.Warnf("✅ Removed session directory: %s", sessionWorkDir)
+					logger.Infof("✅ Removed session directory: %s", sessionWorkDir)
 				}
 			}
 		}
@@ -1311,7 +1311,7 @@ func (s *GitService) syncWorktreeInternal(worktree *models.Worktree, strategy st
 	}
 	s.gitWorktreeManager.UpdateWorktreeStatus(worktree, getSourceRef)
 
-	logger.Warnf("✅ Synced worktree %s with %s strategy", worktree.Name, strategy)
+	logger.Infof("✅ Synced worktree %s with %s strategy", worktree.Name, strategy)
 	return nil
 }
 
@@ -1420,7 +1420,7 @@ func (s *GitService) MergeWorktreeToMain(worktreeID string, squash bool) error {
 		logger.Warnf("📝 Updated worktree %s CommitHash to %s", worktree.Name, newCommitHash)
 	}
 
-	logger.Warnf("✅ Merged worktree %s to main repository", worktree.Name)
+	logger.Infof("✅ Merged worktree %s to main repository", worktree.Name)
 	return nil
 }
 
@@ -1499,9 +1499,9 @@ func (s *GitService) CreateWorktreePreview(worktreeID string) error {
 	}
 
 	if hasUncommittedChanges {
-		logger.Warnf("✅ Preview branch %s %s with uncommitted changes - you can now checkout this branch outside the container", previewBranchName, action)
+		logger.Infof("✅ Preview branch %s %s with uncommitted changes - you can now checkout this branch outside the container", previewBranchName, action)
 	} else {
-		logger.Warnf("✅ Preview branch %s %s - you can now checkout this branch outside the container", previewBranchName, action)
+		logger.Infof("✅ Preview branch %s %s - you can now checkout this branch outside the container", previewBranchName, action)
 	}
 	return nil
 }
@@ -1752,7 +1752,7 @@ func (s *GitService) createWorktreeForExistingRepo(repo *models.Repository, bran
 	// Save state
 	// State persistence handled by state manager
 
-	logger.Warnf("✅ Worktree created for existing repository: %s", repo.ID)
+	logger.Infof("✅ Worktree created for existing repository: %s", repo.ID)
 	return repo, worktree, nil
 }
 
@@ -2099,7 +2099,7 @@ func (s *GitService) syncBranchWithUpstream(worktree *models.Worktree) error {
 		return fmt.Errorf("failed to rebase on upstream: %v\n%s", err, output)
 	}
 
-	logger.Warnf("✅ Successfully synced branch %s with upstream", worktree.Branch)
+	logger.Infof("✅ Successfully synced branch %s with upstream", worktree.Branch)
 	return nil
 }
 
@@ -2234,7 +2234,7 @@ func (s *GitService) RefreshWorktreeStatusByID(worktreeID string) error {
 		return fmt.Errorf("failed to update worktree state: %v", err)
 	}
 
-	logger.Warnf("✅ Force refreshed worktree %s status: %d commits ahead", worktree.Name, worktree.CommitCount)
+	logger.Infof("✅ Force refreshed worktree %s status: %d commits ahead", worktree.Name, worktree.CommitCount)
 	return nil
 }
 
@@ -2286,7 +2286,7 @@ func (s *GitService) CreateFromTemplate(templateID, projectName string) (*models
 			logger.Warnf("❌ Command failed: %v", err)
 			return nil, nil, fmt.Errorf("failed to create project: %v\nOutput: %s", err, string(output))
 		}
-		logger.Warnf("✅ Command completed successfully")
+		logger.Infof("✅ Command completed successfully")
 	}
 
 	// Verify the project directory was created
@@ -2294,7 +2294,7 @@ func (s *GitService) CreateFromTemplate(templateID, projectName string) (*models
 		logger.Warnf("❌ Project directory %s does not exist after command execution", projectPath)
 		return nil, nil, fmt.Errorf("project directory %s was not created by template command", projectPath)
 	}
-	logger.Warnf("✅ Project directory verified: %s", projectPath)
+	logger.Infof("✅ Project directory verified: %s", projectPath)
 
 	// For templates that just create directories, we need to set up the files manually
 	supportedTemplates := templates.GetSupportedTemplates()
@@ -2376,7 +2376,7 @@ func (s *GitService) CreateFromTemplate(templateID, projectName string) (*models
 		return repo, nil, nil
 	}
 
-	logger.Warnf("✅ Successfully created project %s from template %s with initial worktree %s", projectName, templateID, worktree.Name)
+	logger.Infof("✅ Successfully created project %s from template %s with initial worktree %s", projectName, templateID, worktree.Name)
 	return repo, worktree, nil
 }
 
@@ -2391,7 +2391,7 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 		logger.Warnf("❌ Failed to create workspace directory %s: %v", worktree.Path, err)
 		return fmt.Errorf("failed to create workspace directory %s: %v", worktree.Path, err)
 	}
-	logger.Warnf("✅ Created workspace directory: %s", worktree.Path)
+	logger.Infof("✅ Created workspace directory: %s", worktree.Path)
 
 	// Step 2: Determine the correct worktree metadata path
 	// Extract workspace name from the worktree path
@@ -2439,10 +2439,10 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 			return fmt.Errorf("failed to create fresh worktree: %v", err)
 		}
 
-		logger.Warnf("✅ Successfully created fresh worktree %s", worktree.Name)
+		logger.Infof("✅ Successfully created fresh worktree %s", worktree.Name)
 		return nil
 	}
-	logger.Warnf("✅ Found worktree metadata at: %s", worktreeMetadataPath)
+	logger.Infof("✅ Found worktree metadata at: %s", worktreeMetadataPath)
 
 	// Step 3: Create the .git file pointing to the worktree metadata
 	gitFilePath := filepath.Join(worktree.Path, ".git")
@@ -2451,7 +2451,7 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 		logger.Warnf("❌ Failed to create .git file at %s: %v", gitFilePath, err)
 		return fmt.Errorf("failed to create .git file: %v", err)
 	}
-	logger.Warnf("✅ Created .git file pointing to metadata: %s", gitFilePath)
+	logger.Infof("✅ Created .git file pointing to metadata: %s", gitFilePath)
 
 	// Step 4: Restore files from git index
 	logger.Warnf("🔄 Restoring files from git index...")
@@ -2460,14 +2460,14 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 		logger.Warnf("❌ Failed to restore files in %s: %v", worktree.Path, err)
 		return fmt.Errorf("failed to restore files: %v", err)
 	}
-	logger.Warnf("✅ Restored files from git index")
+	logger.Infof("✅ Restored files from git index")
 
 	// Step 5: Verify the restoration
 	statusCmd := []string{"status", "--porcelain"}
 	if output, err := s.operations.ExecuteGit(worktree.Path, statusCmd...); err != nil {
 		logger.Warnf("⚠️ Could not verify git status after restoration: %v", err)
 	} else if strings.TrimSpace(string(output)) == "" {
-		logger.Warnf("✅ Worktree restoration verified - working tree is clean")
+		logger.Infof("✅ Worktree restoration verified - working tree is clean")
 	} else {
 		logger.Warnf("⚠️ Worktree may have uncommitted changes after restoration")
 	}
@@ -2500,7 +2500,7 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 					if err := s.operations.CreateBranch(worktree.Path, niceBranchName, currentCommit); err != nil {
 						logger.Warnf("⚠️ Failed to recreate nice branch %q: %v", niceBranchName, err)
 					} else {
-						logger.Warnf("✅ Successfully recreated nice branch %q pointing to %s", niceBranchName, currentCommit[:8])
+						logger.Infof("✅ Successfully recreated nice branch %q pointing to %s", niceBranchName, currentCommit[:8])
 					}
 				}
 			} else {
@@ -2509,7 +2509,7 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 		}
 	}
 
-	logger.Warnf("✅ Successfully restored worktree %s using manual restoration", worktree.Name)
+	logger.Infof("✅ Successfully restored worktree %s using manual restoration", worktree.Name)
 	return nil
 }
 

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -1176,7 +1176,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 		}
 
 		if !isMerged {
-			logger.Warnf("❌ Branch %s not eligible for cleanup", worktree.Branch)
+			logger.Debugf("❌ Branch %s not eligible for cleanup", worktree.Branch)
 		}
 
 		if isMerged {

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -810,7 +810,7 @@ func (s *GitService) detectLocalRepos() {
 
 		// Check if any worktrees exist for this repo
 		if s.shouldCreateInitialWorktree(repoID) {
-			logger.Warnf("🌱 Creating initial worktree for %s", repoID)
+			logger.Infof("🌱 Creating initial worktree for %s", repoID)
 
 			// Don't proactively prune during runtime - it can delete workspaces being restored
 			// Pruning should only happen on explicit user request or during shutdown
@@ -939,12 +939,12 @@ func (s *GitService) createLocalRepoWorktree(repo *models.Repository, branch, na
 
 	// Execute setup.sh if it exists in the newly created worktree
 	if s.setupExecutor != nil {
-		logger.Warnf("🚀 Scheduling setup.sh execution for local worktree: %s", worktree.Path)
+		logger.Infof("🚀 Scheduling setup.sh execution for local worktree: %s", worktree.Path)
 		// Run setup.sh execution in a goroutine to avoid blocking worktree creation
 		recovery.SafeGo("setup-script-local-"+worktree.Path, func() {
 			// Wait a moment to ensure the worktree is fully ready
 			time.Sleep(2 * time.Second)
-			logger.Warnf("⏰ Starting setup.sh execution for local worktree: %s", worktree.Path)
+			logger.Infof("⏰ Starting setup.sh execution for local worktree: %s", worktree.Path)
 			s.setupExecutor.ExecuteSetupScript(worktree.Path)
 		})
 	} else {
@@ -1093,7 +1093,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 	var cleanedUp []string
 	var errors []error
 
-	logger.Warnf("🧹 Starting cleanup of merged worktrees, checking %d worktrees", len(s.stateManager.GetAllWorktrees()))
+	logger.Infof("🧹 Starting cleanup of merged worktrees, checking %d worktrees", len(s.stateManager.GetAllWorktrees()))
 
 	for _, worktree := range s.stateManager.GetAllWorktrees() {
 		logger.Debugf("🔍 Checking worktree %s: dirty=%v, conflicts=%v, commits_ahead=%d, source=%s",
@@ -1162,7 +1162,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 			}
 
 			// Check if our branch appears in the merged branches list
-			logger.Warnf("📋 Merged branches into %s: %d branches found", worktree.SourceBranch, len(branches))
+			logger.Infof("📋 Merged branches into %s: %d branches found", worktree.SourceBranch, len(branches))
 
 			for _, branch := range branches {
 				// Handle both regular branches and worktree branches (marked with +)
@@ -1180,7 +1180,7 @@ func (s *GitService) CleanupMergedWorktrees() (int, []string, error) {
 		}
 
 		if isMerged {
-			logger.Warnf("🧹 Found merged worktree to cleanup: %s", worktree.Name)
+			logger.Infof("🧹 Found merged worktree to cleanup: %s", worktree.Name)
 
 			// Use the existing deletion logic but don't hold the mutex
 			s.mu.Unlock()
@@ -1211,7 +1211,7 @@ func (s *GitService) cleanupActiveSessions(worktreePath string) {
 	cmd := s.execCommand("pkill", "-f", worktreePath)
 	if err := cmd.Run(); err != nil {
 		// Don't log this as an error since it's common for no processes to be found
-		logger.Warnf("ℹ️ No active processes found for worktree path: %s", worktreePath)
+		logger.Infof("ℹ️ No active processes found for worktree path: %s", worktreePath)
 	} else {
 		logger.Infof("✅ Terminated processes for worktree: %s", worktreePath)
 	}
@@ -1802,12 +1802,12 @@ func (s *GitService) createWorktreeInternalForRepo(repo *models.Repository, sour
 
 	// Execute setup.sh if it exists in the newly created worktree
 	if s.setupExecutor != nil {
-		logger.Warnf("🚀 Scheduling setup.sh execution for worktree: %s", worktree.Path)
+		logger.Infof("🚀 Scheduling setup.sh execution for worktree: %s", worktree.Path)
 		// Run setup.sh execution in a goroutine to avoid blocking worktree creation
 		recovery.SafeGo("setup-script-"+worktree.Path, func() {
 			// Wait a moment to ensure the worktree is fully ready
 			time.Sleep(2 * time.Second)
-			logger.Warnf("⏰ Starting setup.sh execution for worktree: %s", worktree.Path)
+			logger.Infof("⏰ Starting setup.sh execution for worktree: %s", worktree.Path)
 			s.setupExecutor.ExecuteSetupScript(worktree.Path)
 		})
 	} else {
@@ -2362,7 +2362,7 @@ func (s *GitService) CreateFromTemplate(templateID, projectName string) (*models
 	}
 
 	// Create an initial worktree for the template project so the user can immediately start working
-	logger.Warnf("🌱 Creating initial worktree for template project %s", projectName)
+	logger.Infof("🌱 Creating initial worktree for template project %s", projectName)
 
 	// Generate a unique session name for the initial worktree
 	funName := s.generateUniqueSessionName(repo.Path)

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -833,7 +833,7 @@ func (s *GitService) shouldCreateInitialWorktree(repoID string) bool {
 	allWorktrees := s.stateManager.GetAllWorktrees()
 	for _, worktree := range allWorktrees {
 		if worktree.RepoID == repoID {
-			logger.Warnf("🔍 Found existing worktree in state for %s: %s", repoID, worktree.Name)
+			logger.Debugf("🔍 Found existing worktree in state for %s: %s", repoID, worktree.Name)
 			return false
 		}
 	}
@@ -848,14 +848,14 @@ func (s *GitService) shouldCreateInitialWorktree(repoID string) bool {
 			if entry.IsDir() {
 				// Check if this directory is a valid git worktree
 				if _, err := os.Stat(filepath.Join(repoWorkspaceDir, entry.Name(), ".git")); err == nil {
-					logger.Warnf("🔍 Found existing worktree for %s: %s", repoID, entry.Name())
+					logger.Debugf("🔍 Found existing worktree for %s: %s", repoID, entry.Name())
 					return false
 				}
 			}
 		}
 	}
 
-	logger.Warnf("🔍 No existing worktrees found for %s, will create initial worktree", repoID)
+	logger.Debugf("🔍 No existing worktrees found for %s, will create initial worktree", repoID)
 	return true
 }
 

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -579,7 +579,7 @@ func (s *GitService) handleExistingRepository(repoID, repoURL, barePath, branch 
 
 	// Check if the requested branch exists in the bare repo
 	if !s.branchExists(barePath, branch, true) {
-		logger.Warnf("🔄 Branch %s not found, fetching from remote", branch)
+		logger.Infof("🔄 Branch %s not found, fetching from remote", branch)
 		if err := s.fetchBranch(barePath, git.FetchStrategy{
 			Branch:         branch,
 			Depth:          1,
@@ -1365,7 +1365,7 @@ func (s *GitService) MergeWorktreeToMain(worktreeID string, squash bool) error {
 		return fmt.Errorf("local repository %s not found", worktree.RepoID)
 	}
 
-	logger.Warnf("🔄 Merging worktree %s back to main repository", worktree.Name)
+	logger.Infof("🔄 Merging worktree %s back to main repository", worktree.Name)
 
 	// Ensure we have full history for merge operations
 	s.fetchFullHistory(worktree)
@@ -1484,7 +1484,7 @@ func (s *GitService) CreateWorktreePreview(worktreeID string) error {
 	pushArgs := []string{"push"}
 	if shouldForceUpdate {
 		pushArgs = append(pushArgs, "--force")
-		logger.Warnf("🔄 Updating existing preview branch %s", previewBranchName)
+		logger.Infof("🔄 Updating existing preview branch %s", previewBranchName)
 	}
 	pushArgs = append(pushArgs, repo.Path, fmt.Sprintf("%s:refs/heads/%s", worktree.Branch, previewBranchName))
 
@@ -1521,7 +1521,7 @@ func (s *GitService) shouldForceUpdatePreviewBranch(repoPath, previewBranchName 
 	}
 
 	lastCommitMessage := strings.TrimSpace(string(output))
-	logger.Warnf("🔄 Found existing preview branch %s with commit: '%s' - will force update", previewBranchName, lastCommitMessage)
+	logger.Infof("🔄 Found existing preview branch %s with commit: '%s' - will force update", previewBranchName, lastCommitMessage)
 	return true, nil
 }
 
@@ -1673,7 +1673,7 @@ func (s *GitService) RefreshWorktreeStatus(workDir string) error {
 			// Trigger cache refresh if available
 			if s.worktreeCache != nil {
 				s.worktreeCache.ForceRefresh(worktree.ID)
-				logger.Warnf("🔄 Triggered worktree status refresh for %s", worktree.Name)
+				logger.Infof("🔄 Triggered worktree status refresh for %s", worktree.Name)
 			}
 			return nil
 		}
@@ -1729,7 +1729,7 @@ func (s *GitService) createWorktreeForExistingRepo(repo *models.Repository, bran
 	}
 
 	// Always fetch the latest state for checkout operations (full history)
-	logger.Warnf("🔄 Fetching latest state for branch %s", branch)
+	logger.Infof("🔄 Fetching latest state for branch %s", branch)
 	if err := s.fetchBranch(repo.Path, git.FetchStrategy{
 		Branch:         branch,
 		UpdateLocalRef: true,
@@ -1897,7 +1897,7 @@ func (s *GitService) CreatePullRequest(worktreeID, title, body string, forcePush
 	}
 	s.mu.RUnlock()
 
-	logger.Warnf("🔄 Creating pull request for worktree %s", worktree.Name)
+	logger.Infof("🔄 Creating pull request for worktree %s", worktree.Name)
 
 	// Check if base branch exists on remote and push if needed
 	if err := s.ensureBaseBranchOnRemote(worktree, repo); err != nil {
@@ -1951,7 +1951,7 @@ func (s *GitService) UpdatePullRequest(worktreeID, title, body string, forcePush
 	}
 	s.mu.RUnlock()
 
-	logger.Warnf("🔄 Updating pull request for worktree %s", worktree.Name)
+	logger.Infof("🔄 Updating pull request for worktree %s", worktree.Name)
 
 	// Check if base branch exists on remote and push if needed
 	if err := s.ensureBaseBranchOnRemote(worktree, repo); err != nil {
@@ -2007,7 +2007,7 @@ func (s *GitService) ensureBaseBranchOnRemote(worktree *models.Worktree, repo *m
 
 		// Check if base branch exists on remote
 		if err := s.checkBaseBranchOnRemote(worktree, remoteURL); err != nil {
-			logger.Warnf("🔄 Base branch %s not found on remote, pushing it", worktree.SourceBranch)
+			logger.Infof("🔄 Base branch %s not found on remote, pushing it", worktree.SourceBranch)
 			if err := s.pushBaseBranchToRemote(worktree, repo, remoteURL); err != nil {
 				return fmt.Errorf("failed to push base branch to remote: %v", err)
 			}
@@ -2063,7 +2063,7 @@ func (s *GitService) fetchBaseBranchFromOrigin(worktree *models.Worktree) error 
 
 // syncBranchWithUpstream syncs the current branch with upstream when push fails due to being behind
 func (s *GitService) syncBranchWithUpstream(worktree *models.Worktree) error {
-	logger.Warnf("🔄 Syncing branch %s with upstream due to push failure", worktree.Branch)
+	logger.Infof("🔄 Syncing branch %s with upstream due to push failure", worktree.Branch)
 
 	// First, fetch the latest changes from remote
 	if err := s.fetchBranch(worktree.Path, git.FetchStrategy{
@@ -2087,7 +2087,7 @@ func (s *GitService) syncBranchWithUpstream(worktree *models.Worktree) error {
 		return nil
 	}
 
-	logger.Warnf("🔄 Branch %s is %d commits behind remote, syncing", worktree.Branch, behindCount)
+	logger.Infof("🔄 Branch %s is %d commits behind remote, syncing", worktree.Branch, behindCount)
 
 	// Rebase our changes on top of the remote branch
 	output, err = s.runGitCommand(worktree.Path, "rebase", fmt.Sprintf("origin/%s", worktree.Branch))
@@ -2384,7 +2384,7 @@ func (s *GitService) CreateFromTemplate(templateID, projectName string) (*models
 // This method manually restores worktrees by leveraging existing git metadata
 // instead of using `git worktree add` which fails due to registration conflicts
 func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Repository) error {
-	logger.Warnf("🔄 Manually restoring worktree %s at %s (from repo %s)", worktree.Name, worktree.Path, repo.Path)
+	logger.Infof("🔄 Manually restoring worktree %s at %s (from repo %s)", worktree.Name, worktree.Path, repo.Path)
 
 	// Step 1: Create the workspace directory
 	if err := os.MkdirAll(worktree.Path, 0755); err != nil {
@@ -2454,7 +2454,7 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 	logger.Infof("✅ Created .git file pointing to metadata: %s", gitFilePath)
 
 	// Step 4: Restore files from git index
-	logger.Warnf("🔄 Restoring files from git index...")
+	logger.Infof("🔄 Restoring files from git index...")
 	restoreCmd := []string{"restore", "."}
 	if _, err := s.operations.ExecuteGit(worktree.Path, restoreCmd...); err != nil {
 		logger.Warnf("❌ Failed to restore files in %s: %v", worktree.Path, err)
@@ -2474,7 +2474,7 @@ func (s *GitService) RecreateWorktree(worktree *models.Worktree, repo *models.Re
 
 	// Step 6: Recreate nice branch name for renamed worktrees
 	if worktree.HasBeenRenamed {
-		logger.Warnf("🔄 Worktree has been renamed, recreating nice branch name...")
+		logger.Infof("🔄 Worktree has been renamed, recreating nice branch name...")
 
 		// Get current branch (should be refs/catnip/workspacename)
 		currentBranchOutput, err := s.operations.ExecuteGit(worktree.Path, "rev-parse", "--symbolic-full-name", "HEAD")


### PR DESCRIPTION
## Summary

Adjusted log levels throughout the codebase to properly categorize messages based on their severity and purpose. Many informational status messages were incorrectly logged as warnings, and some error messages were logged at the wrong severity level.

## Changes

- **Success messages (✅)**: Changed from `Warnf` to `Infof` for 29 instances of successful operations
- **Progress/status messages (🔄, 🌱, 🚀, ⏰, 🧹, ℹ️, 📋)**: Changed from `Warnf` to `Infof` for 24 instances of normal operational status
- **Diagnostic messages (🔍)**: Changed from `Warnf` to `Debugf` for 11 instances of debug-level diagnostics
- **Error messages in pty.go**: Fixed 27 instances where error messages with ❌ were incorrectly using `Infof` instead of `Errorf` or `Warnf`
- **Flow control message**: Changed "Branch not eligible for cleanup" from `Warnf` to `Debugf` as it represents normal control flow

These changes ensure that log levels accurately reflect message severity, reducing noise in warning/error logs during normal operations while maintaining visibility for actual issues.