### PR TITLE
Fix orphaned git refs cleanup for deleted workspaces

### DIFF
--- a/container/internal/cmd/serve.go
+++ b/container/internal/cmd/serve.go
@@ -167,6 +167,10 @@ func startServer(cmd *cobra.Command) {
 		logger.Debugf("⚠️  Failed to restore state: %v", err)
 	}
 
+	// Clean up orphaned catnip refs on startup
+	logger.Debugf("🧹 Running startup cleanup of orphaned catnip refs")
+	gitService.CleanupAllCatnipRefs()
+
 	// Now initialize local repositories with setup executor properly configured
 	gitService.InitializeLocalRepos()
 	if err := claudeMonitor.Start(); err != nil {

--- a/container/internal/git/worktree_manager.go
+++ b/container/internal/git/worktree_manager.go
@@ -206,7 +206,7 @@ func (w *WorktreeManager) DeleteWorktree(worktree *models.Worktree, repo *models
 		logger.Debugf("✅ Removed preview branch: %s", previewBranchName)
 	}
 
-	// Step 4: Force remove any remaining files
+	// Step 5: Force remove any remaining files
 	if _, err := os.Stat(worktree.Path); err == nil {
 		if removeErr := os.RemoveAll(worktree.Path); removeErr != nil {
 			logger.Warnf("⚠️ Failed to force remove worktree directory %s: %v", worktree.Path, removeErr)
@@ -215,7 +215,7 @@ func (w *WorktreeManager) DeleteWorktree(worktree *models.Worktree, repo *models
 		}
 	}
 
-	// Step 5: Run garbage collection
+	// Step 6: Run garbage collection
 	if err := w.operations.GarbageCollect(repo.Path); err != nil {
 		logger.Warnf("⚠️ Failed to run garbage collection after worktree deletion: %v", err)
 	} else {

--- a/container/internal/git/worktree_manager.go
+++ b/container/internal/git/worktree_manager.go
@@ -189,8 +189,16 @@ func (w *WorktreeManager) DeleteWorktree(worktree *models.Worktree, repo *models
 		}
 	}
 
-	// Step 3: Remove preview branch if it exists
+	// Step 3: Remove catnip ref if it exists
 	workspaceName := ExtractWorkspaceName(worktree.Branch)
+	catnipRef := fmt.Sprintf("refs/catnip/%s", workspaceName)
+	if _, err := w.operations.ExecuteGit(repo.Path, "update-ref", "-d", catnipRef); err == nil {
+		logger.Debugf("✅ Removed catnip ref: %s", catnipRef)
+	} else {
+		logger.Debugf("ℹ️ No catnip ref to remove: %s", catnipRef)
+	}
+
+	// Step 4: Remove preview branch if it exists
 	previewBranchName := fmt.Sprintf("catnip/%s", workspaceName)
 	if err := w.operations.DeleteBranch(repo.Path, previewBranchName, true); err != nil {
 		logger.Debugf("ℹ️ No preview branch to remove: %s", previewBranchName)


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where `refs/catnip/*` git references were not being cleaned up when workspaces were deleted, leading to accumulation of orphaned refs over time. In our case, we had 97 orphaned refs out of 104 total (94% were orphaned).

## Changes

- **Fixed workspace deletion**: The `DeleteWorktree()` function now properly removes the corresponding `refs/catnip/{workspace-name}` ref when a workspace is deleted
- **Enhanced cleanup function**: Made `CleanupAllCatnipRefs()` state.json aware, so it accurately identifies orphaned refs by comparing against tracked workspaces rather than just active worktrees
- **Added startup cleanup**: The cleanup function now runs automatically on server startup to catch any previously orphaned refs

## Impact

This ensures git repositories stay clean and prevents the accumulation of orphaned references that could impact performance and repository size over time. All workspace deletions will now properly clean up their associated git refs, and any missed refs will be caught during server startup.