### PR TITLE
Add React Helmet integration for dynamic document title updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-day-picker": "^9.8.1",
     "react-diff-viewer-continued": "^3.4.0",
     "react-dom": "^19.1.1",
+    "react-helmet-async": "^2.0.5",
     "react-hotkeys-hook": "^5.1.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
+      react-helmet-async:
+        specifier: ^2.0.5
+        version: 2.0.5(react@19.1.1)
       react-hotkeys-hook:
         specifier: ^5.1.0
         version: 5.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -2954,6 +2957,9 @@ packages:
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
 
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -3539,6 +3545,14 @@ packages:
     peerDependencies:
       react: ^19.1.1
 
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-helmet-async@2.0.5:
+    resolution: {integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==}
+    peerDependencies:
+      react: ^16.6.0 || ^17.0.0 || ^18.0.0
+
   react-hotkeys-hook@5.1.0:
     resolution: {integrity: sha512-GCNGXjBzV9buOS3REoQFmSmE4WTvBhYQ0YrAeeMZI83bhXg3dRWsLHXDutcVDdEjwJqJCxk5iewWYX5LtFUd7g==}
     peerDependencies:
@@ -3674,6 +3688,9 @@ packages:
   seroval@1.3.2:
     resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
     engines: {node: '>=10'}
+
+  shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -6909,6 +6926,10 @@ snapshots:
 
   inline-style-parser@0.2.4: {}
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -7653,6 +7674,15 @@ snapshots:
       react: 19.1.1
       scheduler: 0.26.0
 
+  react-fast-compare@3.2.2: {}
+
+  react-helmet-async@2.0.5(react@19.1.1):
+    dependencies:
+      invariant: 2.2.4
+      react: 19.1.1
+      react-fast-compare: 3.2.2
+      shallowequal: 1.1.0
+
   react-hotkeys-hook@5.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -7824,6 +7854,8 @@ snapshots:
       seroval: 1.3.2
 
   seroval@1.3.2: {}
+
+  shallowequal@1.1.0: {}
 
   sharp@0.33.5:
     dependencies:

--- a/src/components/WorkspaceMainContent.tsx
+++ b/src/components/WorkspaceMainContent.tsx
@@ -3,6 +3,7 @@ import { useXTerm } from "react-xtermjs";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { Helmet } from "react-helmet-async";
 import { useWebSocket as useWebSocketContext } from "@/lib/hooks";
 import { FileDropAddon } from "@/lib/file-drop-addon";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
@@ -548,8 +549,16 @@ export function WorkspaceMainContent({
     setIsTerminalMinimized(!isTerminalMinimized);
   }, [isTerminalMinimized, terminalSize]);
 
+  // Generate page title based on session title
+  const pageTitle = worktree.session_title?.title
+    ? `${worktree.session_title.title} - Catnip`
+    : `${worktree.name} - Catnip`;
+
   return (
     <div className="flex flex-1 flex-col h-screen overflow-hidden">
+      <Helmet>
+        <title>{pageTitle}</title>
+      </Helmet>
       <ResizablePanelGroup
         direction="vertical"
         className="h-full"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,25 +1,28 @@
-import { createRoot } from 'react-dom/client'
-import { RouterProvider, createRouter } from '@tanstack/react-router'
-import './index.css'
+import { createRoot } from "react-dom/client";
+import { RouterProvider, createRouter } from "@tanstack/react-router";
+import { HelmetProvider } from "react-helmet-async";
+import "./index.css";
 
 // Import the generated route tree
-import { routeTree } from './routeTree.gen'
+import { routeTree } from "./routeTree.gen";
 
 // Create a new router instance with dynamic base path support
-const basePath = (window as any).__PROXY_BASE_PATH__ || '/'
-console.log('🔧 Router basePath detected:', basePath)
-const router = createRouter({ 
+const basePath = (window as any).__PROXY_BASE_PATH__ || "/";
+console.log("🔧 Router basePath detected:", basePath);
+const router = createRouter({
   routeTree,
-  basepath: basePath === '/' ? undefined : basePath.slice(0, -1) // Remove trailing slash for TanStack Router
-})
+  basepath: basePath === "/" ? undefined : basePath.slice(0, -1), // Remove trailing slash for TanStack Router
+});
 
 // Register the router instance for type safety
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface Register {
-    router: typeof router
+    router: typeof router;
   }
 }
 
-createRoot(document.getElementById('root')!).render(
-  <RouterProvider router={router} />
-)
+createRoot(document.getElementById("root")!).render(
+  <HelmetProvider>
+    <RouterProvider router={router} />
+  </HelmetProvider>,
+);


### PR DESCRIPTION
## Summary

This PR integrates React Helmet to propagate Claude session titles to the browser's document title tag, improving user experience when working with multiple browser tabs.

## Changes

- Added `react-helmet-async` dependency for modern React support
- Wrapped the application root with `HelmetProvider` to enable Helmet functionality
- Implemented dynamic title updates in `WorkspaceMainContent` that display either the Claude session title or workspace name in the browser tab

## Implementation

The document title now follows the pattern:
- `"{Session Title} - Catnip"` when Claude provides a session title
- `"{Workspace Name} - Catnip"` as a fallback when no session title exists

This ensures users can easily identify their workspace context when managing multiple browser tabs, especially during concurrent Claude sessions.