### PR TITLE
Always use repository default branch when creating workspaces from mounted repos

### DIFF
--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -912,7 +912,7 @@ func (s *GitService) handleLocalRepoWorktree(repoID, branch string) (*models.Rep
 		return nil, nil, fmt.Errorf("local repository %s not found - it may not be mounted", repoID)
 	}
 
-	// If no branch specified, use current branch
+	// If no branch specified, use repository's default branch
 	if branch == "" {
 		branch = localRepo.DefaultBranch
 	}

--- a/src/components/NewWorkspaceDialog.tsx
+++ b/src/components/NewWorkspaceDialog.tsx
@@ -75,9 +75,7 @@ export function NewWorkspaceDialog({
       if (initialRepoUrl) {
         // Set initial values when dialog opens with pre-selected repo
         setGithubUrl(initialRepoUrl);
-        if (initialBranch) {
-          setSelectedBranch(initialBranch);
-        }
+        // Don't set initialBranch - let handleRepoChange determine the correct default branch
         // Immediately fetch branches for the initial repo
         void handleRepoChange(initialRepoUrl);
       }

--- a/src/components/NewWorkspaceDialog.tsx
+++ b/src/components/NewWorkspaceDialog.tsx
@@ -255,7 +255,8 @@ export function NewWorkspaceDialog({
         repoId = currentRepo.id;
         branches = await gitApi.fetchBranches(repoId);
 
-        // Always prioritize the repo's default branch
+        // Always prioritize the repo's default branch for mounted repos,
+        // ignoring any initialBranch parameter
         if (
           currentRepo.default_branch &&
           branches.includes(currentRepo.default_branch)


### PR DESCRIPTION
## Summary

Fixed an issue where creating a new workspace from a live mounted repository would use the mounted branch instead of the repository's default branch. This ensures workspaces are always created from `main` or `master` regardless of the mounted repo's current branch.

## Changes

- Updated `NewWorkspaceDialog.tsx` to prioritize the repository's default branch for mounted repos, ignoring the `initialBranch` parameter
- Removed logic that would override branch selection with the mounted branch during dialog initialization
- Fixed misleading comment in `git.go` to accurately reflect default branch usage