### PR TITLE
Add automatic backup for state.json before writes

### DIFF
--- a/container/internal/assets/dist/index.html
+++ b/container/internal/assets/dist/index.html
@@ -1,14 +1,81 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon@2x.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Catnip</title>
-    <script type="module" crossorigin src="/assets/index-CYMgkwam.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-J49f-ohg.css">
+    <title>Catnip - Frontend Not Built</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        background: #1a1a1a;
+        color: #ffffff;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        text-align: center;
+        max-width: 600px;
+      }
+      h1 {
+        color: #ff6b6b;
+        margin-bottom: 1rem;
+      }
+      p {
+        line-height: 1.6;
+        margin-bottom: 1rem;
+        color: #cccccc;
+      }
+      .code {
+        background: #2a2a2a;
+        padding: 1rem;
+        border-radius: 8px;
+        font-family: 'Monaco', 'Menlo', monospace;
+        margin: 1rem 0;
+        color: #00ff88;
+      }
+      .warning {
+        background: #3a2a00;
+        border: 1px solid #ff9900;
+        border-radius: 8px;
+        padding: 1rem;
+        margin: 1rem 0;
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div class="container">
+      <h1>⚠️ Frontend Assets Not Built</h1>
+      
+      <div class="warning">
+        <p><strong>Development Mode:</strong> The frontend assets haven't been built yet.</p>
+      </div>
+      
+      <p>This is a placeholder page served from embedded fallback assets. To get the full Catnip frontend:</p>
+      
+      <div class="code">
+        # Build frontend assets<br>
+        pnpm build
+      </div>
+      
+      <p>Or run in development mode with Vite:</p>
+      
+      <div class="code">
+        # Start frontend dev server<br>
+        pnpm dev
+      </div>
+      
+      <p>Then restart the Go server to pick up the assets.</p>
+      
+      <p><strong>API is still available:</strong></p>
+      <ul style="text-align: left; display: inline-block;">
+        <li><a href="/health" style="color: #00ff88;">/health</a> - Health check</li>
+        <li><a href="/swagger/" style="color: #00ff88;">/swagger/</a> - API documentation</li>
+        <li><a href="/v1/" style="color: #00ff88;">/v1/</a> - API endpoints</li>
+      </ul>
+    </div>
   </body>
 </html>

--- a/container/internal/assets/dist/index.html
+++ b/container/internal/assets/dist/index.html
@@ -1,81 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/favicon@2x.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Catnip - Frontend Not Built</title>
-    <style>
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        margin: 0;
-        padding: 2rem;
-        background: #1a1a1a;
-        color: #ffffff;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .container {
-        text-align: center;
-        max-width: 600px;
-      }
-      h1 {
-        color: #ff6b6b;
-        margin-bottom: 1rem;
-      }
-      p {
-        line-height: 1.6;
-        margin-bottom: 1rem;
-        color: #cccccc;
-      }
-      .code {
-        background: #2a2a2a;
-        padding: 1rem;
-        border-radius: 8px;
-        font-family: 'Monaco', 'Menlo', monospace;
-        margin: 1rem 0;
-        color: #00ff88;
-      }
-      .warning {
-        background: #3a2a00;
-        border: 1px solid #ff9900;
-        border-radius: 8px;
-        padding: 1rem;
-        margin: 1rem 0;
-      }
-    </style>
+    <title>Catnip</title>
+    <script type="module" crossorigin src="/assets/index-CYMgkwam.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-J49f-ohg.css">
   </head>
   <body>
-    <div class="container">
-      <h1>⚠️ Frontend Assets Not Built</h1>
-      
-      <div class="warning">
-        <p><strong>Development Mode:</strong> The frontend assets haven't been built yet.</p>
-      </div>
-      
-      <p>This is a placeholder page served from embedded fallback assets. To get the full Catnip frontend:</p>
-      
-      <div class="code">
-        # Build frontend assets<br>
-        pnpm build
-      </div>
-      
-      <p>Or run in development mode with Vite:</p>
-      
-      <div class="code">
-        # Start frontend dev server<br>
-        pnpm dev
-      </div>
-      
-      <p>Then restart the Go server to pick up the assets.</p>
-      
-      <p><strong>API is still available:</strong></p>
-      <ul style="text-align: left; display: inline-block;">
-        <li><a href="/health" style="color: #00ff88;">/health</a> - Health check</li>
-        <li><a href="/swagger/" style="color: #00ff88;">/swagger/</a> - API documentation</li>
-        <li><a href="/v1/" style="color: #00ff88;">/v1/</a> - API endpoints</li>
-      </ul>
-    </div>
+    <div id="root"></div>
   </body>
 </html>

--- a/container/internal/services/worktree_state_manager.go
+++ b/container/internal/services/worktree_state_manager.go
@@ -510,24 +510,6 @@ func (wsm *WorktreeStateManager) saveStateInternal() error {
 	return os.WriteFile(stateFile, data, 0644)
 }
 
-// copyFile copies a file from src to dst
-func copyFile(src, dst string) error {
-	sourceFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer sourceFile.Close()
-
-	destFile, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer destFile.Close()
-
-	_, err = destFile.ReadFrom(sourceFile)
-	return err
-}
-
 // loadState loads state from disk
 func (wsm *WorktreeStateManager) loadState() error {
 	stateFile := filepath.Join(wsm.stateDir, "state.json")

--- a/container/internal/services/worktree_state_manager.go
+++ b/container/internal/services/worktree_state_manager.go
@@ -490,8 +490,21 @@ func (wsm *WorktreeStateManager) saveStateInternal() error {
 	}
 
 	stateFile := filepath.Join(wsm.stateDir, "state.json")
+	backupFile := filepath.Join(wsm.stateDir, "state.json.backup")
+
 	if err := os.MkdirAll(wsm.stateDir, 0755); err != nil {
 		return err
+	}
+
+	// Create backup of existing state file before writing new one
+	if _, err := os.Stat(stateFile); err == nil {
+		// State file exists, create backup
+		if err := copyFile(stateFile, backupFile); err != nil {
+			logger.Warnf("⚠️ Failed to create state backup: %v", err)
+			// Continue with write anyway - backup failure shouldn't prevent state saving
+		} else {
+			logger.Debugf("📦 Created state backup: %s", backupFile)
+		}
 	}
 
 	return os.WriteFile(stateFile, data, 0644)

--- a/container/internal/services/worktree_state_manager.go
+++ b/container/internal/services/worktree_state_manager.go
@@ -510,6 +510,24 @@ func (wsm *WorktreeStateManager) saveStateInternal() error {
 	return os.WriteFile(stateFile, data, 0644)
 }
 
+// copyFile copies a file from src to dst
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = destFile.ReadFrom(sourceFile)
+	return err
+}
+
 // loadState loads state from disk
 func (wsm *WorktreeStateManager) loadState() error {
 	stateFile := filepath.Join(wsm.stateDir, "state.json")


### PR DESCRIPTION
## Summary

Adds automatic backup functionality to protect against state file corruption or loss. The system now creates a `state.json.backup` file before writing any changes to the main state file.

## Changes

- Modified `saveStateInternal()` in `worktree_state_manager.go` to create a backup copy of the existing state file before overwriting
- Backup failures are logged as warnings but don't block state writes to ensure system functionality
- All state modification paths (AddRepository, AddWorktree, UpdateWorktree, DeleteWorktree, etc.) automatically benefit from this protection since they all use the same internal save method

## Motivation

This change was implemented after discovering that the state file (`/volume/state.json`) could be destroyed under certain conditions, leading to loss of workspace configuration. The backup provides a recovery mechanism in case the primary state file becomes corrupted during write operations.