### PR TITLE
Adjust log levels for routine operations and add remote existence check

### DIFF
--- a/container/internal/git/worktree_manager.go
+++ b/container/internal/git/worktree_manager.go
@@ -117,12 +117,19 @@ func (w *WorktreeManager) CreateLocalWorktree(req CreateWorktreeRequest) (*model
 	// This allows us to push nice branches back to the main repo for external access
 	// Local repos are identified by repo IDs starting with "local/"
 	if strings.HasPrefix(req.Repository.ID, "local/") {
-		// Add "catnip-live" remote pointing to the main repository
-		if err := w.operations.AddRemote(worktreePath, "catnip-live", req.Repository.Path); err != nil {
-			// Log warning but don't fail - remote might already exist
-			logger.Warnf("⚠️ Failed to add catnip-live remote (may already exist): %v", err)
+		// Check if catnip-live remote already exists
+		remotes, err := w.operations.GetRemotes(worktreePath)
+		if err != nil {
+			logger.Debugf("🔍 Could not check existing remotes: %v", err)
+		} else if _, exists := remotes["catnip-live"]; exists {
+			logger.Debugf("📍 Remote 'catnip-live' already exists, skipping add")
 		} else {
-			logger.Debugf("✅ Added 'catnip-live' remote pointing to main repository at %s", req.Repository.Path)
+			// Add "catnip-live" remote pointing to the main repository
+			if err := w.operations.AddRemote(worktreePath, "catnip-live", req.Repository.Path); err != nil {
+				logger.Warnf("⚠️ Failed to add catnip-live remote: %v", err)
+			} else {
+				logger.Debugf("✅ Added 'catnip-live' remote pointing to main repository at %s", req.Repository.Path)
+			}
 		}
 	}
 

--- a/container/internal/services/claude_monitor.go
+++ b/container/internal/services/claude_monitor.go
@@ -827,7 +827,7 @@ func (s *ClaudeMonitorService) startWorktreeTodoMonitor(worktreeID, worktreePath
 	projectDir := s.findProjectDirectory(projectDirName)
 
 	if projectDir == "" {
-		logger.Warnf("⚠️  No Claude project directory found for %s (expected: %s)", worktreePath, projectDirName)
+		logger.Debugf("⚠️  No Claude project directory found for %s (expected: %s)", worktreePath, projectDirName)
 		return
 	}
 

--- a/container/internal/services/port_monitor.go
+++ b/container/internal/services/port_monitor.go
@@ -477,7 +477,7 @@ func (pm *PortMonitor) checkHTTPHealth(service *ServiceInfo) HTTPHealthResult {
 
 	// Log the failure reason for better debugging
 	if lastError != nil {
-		logger.Warnf("⚠️  Port %d HTTP health check failed: %v (command: %s, working dir: %s)",
+		logger.Infof("⚠️  Port %d HTTP health check failed: %v (command: %s, working dir: %s)",
 			service.Port, lastError, service.Command, service.WorkingDir)
 	}
 
@@ -491,7 +491,7 @@ func (pm *PortMonitor) checkHTTPHealth(service *ServiceInfo) HTTPHealthResult {
 func (pm *PortMonitor) checkTCPHealth(service *ServiceInfo) bool {
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", service.Port), 2*time.Second)
 	if err != nil {
-		logger.Warnf("⚠️  Port %d TCP health check failed: %v (command: %s, working dir: %s)",
+		logger.Infof("⚠️  Port %d TCP health check failed: %v (command: %s, working dir: %s)",
 			service.Port, err, service.Command, service.WorkingDir)
 		return false
 	}


### PR DESCRIPTION
This PR adjusts log levels for several routine operations that were unnecessarily verbose during normal operation.

## Changes
- Changed health check failure messages from `WRN` to `INF` level since these are normal during service startup
- Changed Claude project directory not found messages from `WRN` to `DBG` level as these are expected for non-Claude projects
- Added remote existence check before attempting to add `catnip-live` remote to prevent unnecessary error messages on boot

## Impact
These changes reduce log noise during normal operations while preserving the ability to see these messages when debugging. The remote existence check prevents redundant git operations and eliminates confusing error messages when remotes already exist.