### PR TITLE
Add Chrome app installation and notification support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon@2x.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="manifest" href="/manifest.json" />
     <title>Catnip</title>
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,36 @@
+{
+  "name": "Catnip",
+  "short_name": "Catnip",
+  "description": "Agentic coding environment",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "32x32",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/favicon@2x.png",
+      "sizes": "64x64",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/logo.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/logo@2x.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/lib/useNotifications.ts
+++ b/src/lib/useNotifications.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect } from "react";
+
+export type NotificationPermission = "default" | "granted" | "denied";
+
+export function useNotifications() {
+  const [permission, setPermission] =
+    useState<NotificationPermission>("default");
+  const [isSupported, setIsSupported] = useState(false);
+
+  useEffect(() => {
+    const supported = "Notification" in window;
+    setIsSupported(supported);
+
+    if (supported) {
+      setPermission(Notification.permission);
+    }
+  }, []);
+
+  const requestPermission = async (): Promise<NotificationPermission> => {
+    if (!isSupported) {
+      throw new Error("Notifications are not supported in this browser");
+    }
+
+    try {
+      const result = await Notification.requestPermission();
+      setPermission(result);
+      return result;
+    } catch (error) {
+      console.error("Error requesting notification permission:", error);
+      throw error;
+    }
+  };
+
+  const showNotification = (title: string, options?: NotificationOptions) => {
+    if (!isSupported) {
+      throw new Error("Notifications are not supported in this browser");
+    }
+
+    if (permission !== "granted") {
+      throw new Error("Notification permission not granted");
+    }
+
+    return new Notification(title, options);
+  };
+
+  return {
+    permission,
+    isSupported,
+    requestPermission,
+    showNotification,
+    canShowNotifications: isSupported && permission === "granted",
+  };
+}


### PR DESCRIPTION
## Summary

Implemented lightweight Chrome app installability without the overhead of a full PWA setup. Added a web app manifest and notification permission utilities to enable the app to be installed as a Chrome app and request notification access.

## Changes

- Created `public/manifest.json` with app metadata and icon configurations for Chrome installation
- Updated `index.html` to include manifest link and theme-color meta tag
- Added `useNotifications` hook for managing notification permissions and displaying notifications

## Implementation Notes

Chose a manual manifest approach over vite-pwa since service workers and offline functionality weren't needed. This keeps the implementation lightweight while still enabling Chrome app installation. The notification hook provides a clean API for requesting permissions and showing notifications when needed.