### PR TITLE
Fix Claude session state transitions and reduce log noise

### DIFF
--- a/container/internal/services/claude_monitor.go
+++ b/container/internal/services/claude_monitor.go
@@ -1329,13 +1329,10 @@ func (s *ClaudeMonitorService) GetClaudeActivityState(worktreePath string) model
 		}
 	}
 
-	// Fallback to PTY-based activity tracking for compatibility
-	// Check activity using the general activity tracking
-	if s.claudeService.IsActiveSession(worktreePath, 2*time.Minute) {
-		return models.ClaudeActive
-	}
+	// Without UserPromptSubmit hook events, we should be more conservative about "active" state
+	// Only PTY connection doesn't mean Claude is actively generating - wait for UserPromptSubmit
 
-	// Check if there's any recent activity (within 10 minutes) to determine if "running"
+	// Check if there's any recent PTY activity (within 10 minutes) to determine if "running"
 	if s.claudeService.IsActiveSession(worktreePath, 10*time.Minute) {
 		return models.ClaudeRunning
 	}

--- a/container/internal/services/worktree_state_manager.go
+++ b/container/internal/services/worktree_state_manager.go
@@ -502,8 +502,6 @@ func (wsm *WorktreeStateManager) saveStateInternal() error {
 		if err := copyFile(stateFile, backupFile); err != nil {
 			logger.Warnf("⚠️ Failed to create state backup: %v", err)
 			// Continue with write anyway - backup failure shouldn't prevent state saving
-		} else {
-			logger.Debugf("📦 Created state backup: %s", backupFile)
 		}
 	}
 

--- a/container/internal/tui/app.go
+++ b/container/internal/tui/app.go
@@ -121,8 +121,7 @@ func (a *App) Run(ctx context.Context, workDir string, customPorts []string) (st
 				if pf, ok := payload["port"].(float64); ok {
 					cp := int(pf)
 					a.portForwarder.EnsureForward(cp)
-					// Immediately announce mapping in case backend restarted
-					a.portForwarder.ReannounceMappings()
+					// Note: EnsureForward already announces the new mapping
 				}
 			}
 		case PortClosedEvent:


### PR DESCRIPTION
## Summary

This PR fixes the premature transition of Claude sessions from "running" to "active" state and removes unnecessary log noise.

## Changes

- **Fixed Claude session state logic**: Sessions now remain in "running" state when only a PTY connection exists, transitioning to "active" only after receiving a `UserPromptSubmit` hook event from Claude. This provides more accurate activity tracking.

- **Removed redundant port mapping requests**: Eliminated duplicate `/v1/ports/mappings` POST requests by removing an unnecessary `ReannounceMappings()` call that was re-announcing all existing port mappings every time a new port was opened.

- **Cleaned up noisy logging**: Removed the frequent "Created state backup" debug log that was cluttering output without providing useful information.

## Impact

These changes improve the accuracy of Claude session state tracking in the UI and reduce both network traffic and log noise, resulting in a cleaner development experience.