### PR TITLE
Sort workspaces by creation date instead of alphabetically

### DIFF
--- a/src/components/WorkspaceLeftSidebar.tsx
+++ b/src/components/WorkspaceLeftSidebar.tsx
@@ -99,10 +99,25 @@ export function WorkspaceLeftSidebar() {
       .map((repoId) => {
         const repo = getRepository(repoId);
         const worktrees = getWorktreesByRepo(repoId);
-        // Sort worktrees by name in lexical order
-        const sortedWorktrees = worktrees.sort((a, b) =>
-          a.name.localeCompare(b.name),
-        );
+        // Sort worktrees by created_at (descending), fallback to last_accessed (descending), then name
+        const sortedWorktrees = worktrees.sort((a, b) => {
+          // Primary sort: created_at (descending - most recent first)
+          const aCreated = new Date(a.created_at).getTime();
+          const bCreated = new Date(b.created_at).getTime();
+          if (aCreated !== bCreated) {
+            return bCreated - aCreated;
+          }
+
+          // Secondary sort: last_accessed (descending - most recent first)
+          const aAccessed = new Date(a.last_accessed).getTime();
+          const bAccessed = new Date(b.last_accessed).getTime();
+          if (aAccessed !== bAccessed) {
+            return bAccessed - aAccessed;
+          }
+
+          // Tertiary sort: name (lexical)
+          return a.name.localeCompare(b.name);
+        });
         return repo ? { ...repo, worktrees: sortedWorktrees } : null;
       })
       .filter((repo): repo is NonNullable<typeof repo> => repo !== null)


### PR DESCRIPTION
## Summary

Updated the workspace sorting logic in the left sidebar to display workspaces in descending order by their creation timestamp, providing a more intuitive chronological view of workspaces.

## Changes

- Modified `WorkspaceLeftSidebar.tsx` to sort workspaces by `created_at` (most recent first)
- Added fallback sorting by `last_accessed` timestamp when creation dates are equal
- Retained alphabetical sorting by name as a final tiebreaker for identical timestamps

This change improves the user experience by showing the most recently created workspaces at the top of the list, making it easier to find and access newer work while maintaining a predictable sort order for workspaces created at the same time.