### PR TITLE
Add native macOS notification support via TUI app

### DIFF
--- a/container/.goreleaser.yml
+++ b/container/.goreleaser.yml
@@ -15,9 +15,12 @@ git:
 
 # Build configuration
 builds:
-  - id: catnip
+  # Linux and FreeBSD builds without CGO
+  - id: catnip-no-cgo
     main: ./cmd/cli/main.go
     binary: catnip
+    env:
+      - CGO_ENABLED=0
 
     # Build flags and ldflags for version injection
     flags:
@@ -29,29 +32,44 @@ builds:
       - -X main.date={{.Date}}
       - -X main.builtBy=goreleaser
 
-    # Target platforms
+    # Target platforms for CGO-disabled builds
     goos:
       - linux
-      - darwin
       - freebsd
 
     goarch:
       - amd64
       - arm64
 
-    # ARM variants
-    # goarm:
-
     # Ignore combinations that don't make sense
     ignore:
-      - goos: darwin
-        goarch: "386"
-      - goos: darwin
-        goarch: arm
       - goos: freebsd
         goarch: arm64
-      - goos: freebsd
-        goarch: arm
+        
+  # macOS builds with CGO for native notifications
+  - id: catnip-macos
+    main: ./cmd/cli/main.go
+    binary: catnip
+    env:
+      - CGO_ENABLED=1
+
+    # Build flags and ldflags for version injection
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+      - -X main.builtBy=goreleaser
+
+    # Target platforms for CGO-enabled builds (macOS only)
+    goos:
+      - darwin
+
+    goarch:
+      - amd64
+      - arm64
 
 # Code signing and notarization for macOS binaries
 notarize:
@@ -72,7 +90,7 @@ notarize:
 archives:
   - id: default
     # Modern v2 syntax: use ids instead of builds
-    ids: [catnip]
+    ids: [catnip-no-cgo, catnip-macos]
 
     # Archive name template
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
@@ -261,6 +279,5 @@ before:
     - go generate ./...
 
 # Build environment
-env:
-  - CGO_ENABLED=0
+# CGO settings are per-build now - see builds section
 # Git tag configuration moved to top git section

--- a/container/docs/docs.go
+++ b/container/docs/docs.go
@@ -1054,6 +1054,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/notifications": {
+            "post": {
+                "description": "Sends a notification event to all connected SSE clients, including the TUI app which can display native macOS notifications",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Send notification",
+                "parameters": [
+                    {
+                        "description": "Notification details",
+                        "name": "notification",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handlers.NotificationPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success response",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/ports": {
             "get": {
                 "description": "Returns a list of all currently detected ports with their service information",
@@ -2475,6 +2521,7 @@ const docTemplate = `{
         "internal_handlers.EventType": {
             "type": "string",
             "enum": [
+                "notification:show",
                 "port:opened",
                 "port:closed",
                 "git:dirty",
@@ -2496,6 +2543,7 @@ const docTemplate = `{
                 "session:stopped"
             ],
             "x-enum-varnames": [
+                "NotificationEvent",
                 "PortOpenedEvent",
                 "PortClosedEvent",
                 "GitDirtyEvent",
@@ -2565,6 +2613,20 @@ const docTemplate = `{
                     "description": "Optional custom branch name to graduate to",
                     "type": "string",
                     "example": "feature/add-auth"
+                }
+            }
+        },
+        "internal_handlers.NotificationPayload": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "subtitle": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
                 }
             }
         },

--- a/container/docs/swagger.json
+++ b/container/docs/swagger.json
@@ -1051,6 +1051,52 @@
                 }
             }
         },
+        "/v1/notifications": {
+            "post": {
+                "description": "Sends a notification event to all connected SSE clients, including the TUI app which can display native macOS notifications",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Send notification",
+                "parameters": [
+                    {
+                        "description": "Notification details",
+                        "name": "notification",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handlers.NotificationPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success response",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/ports": {
             "get": {
                 "description": "Returns a list of all currently detected ports with their service information",
@@ -2472,6 +2518,7 @@
         "internal_handlers.EventType": {
             "type": "string",
             "enum": [
+                "notification:show",
                 "port:opened",
                 "port:closed",
                 "git:dirty",
@@ -2493,6 +2540,7 @@
                 "session:stopped"
             ],
             "x-enum-varnames": [
+                "NotificationEvent",
                 "PortOpenedEvent",
                 "PortClosedEvent",
                 "GitDirtyEvent",
@@ -2562,6 +2610,20 @@
                     "description": "Optional custom branch name to graduate to",
                     "type": "string",
                     "example": "feature/add-auth"
+                }
+            }
+        },
+        "internal_handlers.NotificationPayload": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "subtitle": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
                 }
             }
         },

--- a/container/docs/swagger.yaml
+++ b/container/docs/swagger.yaml
@@ -790,6 +790,7 @@ definitions:
     type: object
   internal_handlers.EventType:
     enum:
+    - notification:show
     - port:opened
     - port:closed
     - git:dirty
@@ -811,6 +812,7 @@ definitions:
     - session:stopped
     type: string
     x-enum-varnames:
+    - NotificationEvent
     - PortOpenedEvent
     - PortClosedEvent
     - GitDirtyEvent
@@ -867,6 +869,15 @@ definitions:
       branch_name:
         description: Optional custom branch name to graduate to
         example: feature/add-auth
+        type: string
+    type: object
+  internal_handlers.NotificationPayload:
+    properties:
+      body:
+        type: string
+      subtitle:
+        type: string
+      title:
         type: string
     type: object
   internal_handlers.SSEMessage:
@@ -1707,6 +1718,37 @@ paths:
       summary: Cleanup merged worktrees
       tags:
       - git
+  /v1/notifications:
+    post:
+      consumes:
+      - application/json
+      description: Sends a notification event to all connected SSE clients, including
+        the TUI app which can display native macOS notifications
+      parameters:
+      - description: Notification details
+        in: body
+        name: notification
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handlers.NotificationPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success response
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Send notification
+      tags:
+      - notifications
   /v1/ports:
     get:
       consumes:

--- a/container/entitlements.plist
+++ b/container/entitlements.plist
@@ -25,5 +25,9 @@
     <!-- Allow outbound network connections -->
     <key>com.apple.security.network.server</key>
     <true/>
+    
+    <!-- User Notifications entitlement for native macOS notifications -->
+    <key>com.apple.developer.usernotifications.communication</key>
+    <true/>
 </dict>
 </plist>

--- a/container/internal/cmd/serve.go
+++ b/container/internal/cmd/serve.go
@@ -278,6 +278,10 @@ func startServer(cmd *cobra.Command) {
 	// Events routes
 	v1.Get("/events", eventsHandler.HandleSSE)
 
+	// Notification routes
+	notificationHandler := handlers.NewNotificationHandler(eventsHandler)
+	v1.Post("/notifications", notificationHandler.HandleNotification)
+
 	// Proxy routes for detected services (must be before dev middleware)
 	// Will validate port numbers in handler and call Next() if invalid
 	app.All("/:port", proxyHandler.ProxyToPort)

--- a/container/internal/handlers/events.go
+++ b/container/internal/handlers/events.go
@@ -42,6 +42,7 @@ const (
 	WorktreeTodosUpdatedEvent  EventType = "worktree:todos_updated"
 	SessionTitleUpdatedEvent   EventType = "session:title_updated"
 	SessionStoppedEvent        EventType = "session:stopped"
+	NotificationEvent          EventType = "notification:show"
 )
 
 type AppEvent struct {

--- a/container/internal/handlers/notifications.go
+++ b/container/internal/handlers/notifications.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/vanpelt/catnip/internal/logger"
+)
+
+// NotificationEvent constant for SSE
+const NotificationEvent EventType = "notification:show"
+
+// NotificationPayload represents a notification request
+type NotificationPayload struct {
+	Title    string `json:"title"`
+	Body     string `json:"body"`
+	Subtitle string `json:"subtitle,omitempty"`
+}
+
+// NotificationHandler handles notification requests
+type NotificationHandler struct {
+	eventsHandler *EventsHandler
+}
+
+// NewNotificationHandler creates a new notification handler
+func NewNotificationHandler(eventsHandler *EventsHandler) *NotificationHandler {
+	return &NotificationHandler{
+		eventsHandler: eventsHandler,
+	}
+}
+
+// HandleNotification sends a notification event via SSE
+// @Summary Send notification
+// @Description Sends a notification event to all connected SSE clients, including the TUI app which can display native macOS notifications
+// @Tags notifications
+// @Accept json
+// @Produce json
+// @Param notification body NotificationPayload true "Notification details"
+// @Success 200 {object} map[string]string "Success response"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Router /v1/notifications [post]
+func (h *NotificationHandler) HandleNotification(c *fiber.Ctx) error {
+	var payload NotificationPayload
+
+	if err := c.BodyParser(&payload); err != nil {
+		logger.Warnf("Failed to parse notification request: %v", err)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid notification payload",
+		})
+	}
+
+	// Validate required fields
+	if payload.Title == "" || payload.Body == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Title and body are required",
+		})
+	}
+
+	// Broadcast notification event via SSE
+	h.eventsHandler.broadcastEvent(AppEvent{
+		Type: NotificationEvent,
+		Payload: NotificationPayload{
+			Title:    payload.Title,
+			Body:     payload.Body,
+			Subtitle: payload.Subtitle,
+		},
+	})
+
+	logger.Infof("Notification sent: %s", payload.Title)
+
+	return c.JSON(fiber.Map{
+		"status": "sent",
+	})
+}

--- a/container/internal/tui/notifications_darwin.go
+++ b/container/internal/tui/notifications_darwin.go
@@ -1,0 +1,101 @@
+//go:build darwin
+
+package tui
+
+/*
+#cgo CFLAGS: -x objective-c -mmacosx-version-min=10.14
+#cgo LDFLAGS: -framework Foundation -framework UserNotifications
+
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+#import <dispatch/dispatch.h>
+
+static int notificationPermissionGranted = 0;
+
+void requestNotificationPermission() {
+    @autoreleasepool {
+        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+        [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge)
+            completionHandler:^(BOOL granted, NSError * _Nullable error) {
+                notificationPermissionGranted = granted ? 1 : 0;
+                dispatch_semaphore_signal(semaphore);
+            }];
+
+        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    }
+}
+
+void sendNotification(const char* title, const char* body, const char* subtitle) {
+    @autoreleasepool {
+        if (!notificationPermissionGranted) {
+            requestNotificationPermission();
+        }
+
+        UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+        content.title = [NSString stringWithUTF8String:title];
+        content.body = [NSString stringWithUTF8String:body];
+        if (subtitle && strlen(subtitle) > 0) {
+            content.subtitle = [NSString stringWithUTF8String:subtitle];
+        }
+        content.sound = [UNNotificationSound defaultSound];
+
+        // Create trigger (immediate delivery)
+        UNTimeIntervalNotificationTrigger *trigger =
+            [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:0.1 repeats:NO];
+
+        // Create unique identifier
+        NSString *identifier = [[NSUUID UUID] UUIDString];
+
+        // Create request
+        UNNotificationRequest *request =
+            [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];
+
+        // Add notification request
+        [[UNUserNotificationCenter currentNotificationCenter]
+            addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
+                if (error) {
+                    NSLog(@"Error sending notification: %@", error.localizedDescription);
+                }
+            }];
+    }
+}
+
+int isNotificationPermissionGranted() {
+    return notificationPermissionGranted;
+}
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+func init() {
+	// Request permission on startup
+	C.requestNotificationPermission()
+}
+
+// SendNativeNotification sends a native macOS notification
+func SendNativeNotification(title, body, subtitle string) error {
+	cTitle := C.CString(title)
+	cBody := C.CString(body)
+	cSubtitle := C.CString(subtitle)
+
+	defer C.free(unsafe.Pointer(cTitle))
+	defer C.free(unsafe.Pointer(cBody))
+	defer C.free(unsafe.Pointer(cSubtitle))
+
+	C.sendNotification(cTitle, cBody, cSubtitle)
+	return nil
+}
+
+// IsNotificationSupported returns true on macOS
+func IsNotificationSupported() bool {
+	return true
+}
+
+// HasNotificationPermission checks if notification permission is granted
+func HasNotificationPermission() bool {
+	return C.isNotificationPermissionGranted() == 1
+}

--- a/container/internal/tui/notifications_other.go
+++ b/container/internal/tui/notifications_other.go
@@ -1,0 +1,23 @@
+//go:build !darwin
+
+package tui
+
+import (
+	"fmt"
+)
+
+// SendNativeNotification is a no-op on non-macOS platforms
+func SendNativeNotification(title, body, subtitle string) error {
+	debugLog("Notification (unsupported platform): %s - %s", title, body)
+	return fmt.Errorf("native notifications not supported on this platform")
+}
+
+// IsNotificationSupported returns false on non-macOS platforms
+func IsNotificationSupported() bool {
+	return false
+}
+
+// HasNotificationPermission always returns false on non-macOS platforms
+func HasNotificationPermission() bool {
+	return false
+}

--- a/container/internal/tui/sse_client.go
+++ b/container/internal/tui/sse_client.go
@@ -43,6 +43,7 @@ const (
 	ContainerStatusEvent = "container:status"
 	PortMappedEvent      = "port:mapped"
 	HeartbeatEvent       = "heartbeat"
+	NotificationEvent    = "notification:show"
 )
 
 // SSE event messages are defined in messages.go
@@ -260,6 +261,22 @@ func (c *SSEClient) processEvent(data string) {
 		// Heartbeat confirms connection is still alive
 		// No need to log every heartbeat to avoid spam
 		// debugLog("SSE heartbeat received")
+
+	case NotificationEvent:
+		if payload, ok := msg.Event.Payload.(map[string]interface{}); ok {
+			title, _ := payload["title"].(string)
+			body, _ := payload["body"].(string)
+			subtitle, _ := payload["subtitle"].(string)
+
+			// Send native notification if supported
+			if IsNotificationSupported() {
+				if err := SendNativeNotification(title, body, subtitle); err != nil {
+					debugLog("TUI SSE: Failed to send notification: %v", err)
+				} else {
+					debugLog("TUI SSE: Sent notification: %s", title)
+				}
+			}
+		}
 
 	default:
 		// Log other event types for now


### PR DESCRIPTION
## Summary

Replaces browser-based Chrome notifications with native macOS notifications when the TUI app is running. Notifications are sent from the containerized frontend through the host TUI application via the existing SSE connection, providing a more integrated desktop experience.

## Implementation

- **Platform-specific notification handling**: Uses macOS UserNotifications framework (via CGO) for native notifications on macOS, with a no-op fallback for Linux/FreeBSD builds
- **Seamless fallback**: Frontend attempts native notifications first via `/v1/notifications` API endpoint, automatically falling back to browser notifications if the TUI isn't connected
- **Build configuration**: Updated GoReleaser to build with CGO enabled only for macOS targets, keeping Linux builds lightweight without CGO dependencies
- **Communication flow**: Frontend → Container API → SSE broadcast → TUI app → Native notification

## Key Changes

- Added notification relay system through existing SSE infrastructure
- Enhanced frontend notification hook to try native notifications before browser fallback
- Updated entitlements.plist with user notification permissions for signed macOS builds
- Maintains full backward compatibility with existing browser notification system