### PR TITLE
Refactor template repositories to use persistent bare storage

### DIFF
--- a/container/internal/assets/dist/index.html
+++ b/container/internal/assets/dist/index.html
@@ -1,16 +1,81 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon@2x.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#000000" />
-    <link rel="manifest" href="/manifest.json" />
-    <title>Catnip</title>
-    <script type="module" crossorigin src="/assets/index-DIOoOkzz.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CXhe8UEv.css">
+    <title>Catnip - Frontend Not Built</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        background: #1a1a1a;
+        color: #ffffff;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        text-align: center;
+        max-width: 600px;
+      }
+      h1 {
+        color: #ff6b6b;
+        margin-bottom: 1rem;
+      }
+      p {
+        line-height: 1.6;
+        margin-bottom: 1rem;
+        color: #cccccc;
+      }
+      .code {
+        background: #2a2a2a;
+        padding: 1rem;
+        border-radius: 8px;
+        font-family: 'Monaco', 'Menlo', monospace;
+        margin: 1rem 0;
+        color: #00ff88;
+      }
+      .warning {
+        background: #3a2a00;
+        border: 1px solid #ff9900;
+        border-radius: 8px;
+        padding: 1rem;
+        margin: 1rem 0;
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div class="container">
+      <h1>⚠️ Frontend Assets Not Built</h1>
+      
+      <div class="warning">
+        <p><strong>Development Mode:</strong> The frontend assets haven't been built yet.</p>
+      </div>
+      
+      <p>This is a placeholder page served from embedded fallback assets. To get the full Catnip frontend:</p>
+      
+      <div class="code">
+        # Build frontend assets<br>
+        pnpm build
+      </div>
+      
+      <p>Or run in development mode with Vite:</p>
+      
+      <div class="code">
+        # Start frontend dev server<br>
+        pnpm dev
+      </div>
+      
+      <p>Then restart the Go server to pick up the assets.</p>
+      
+      <p><strong>API is still available:</strong></p>
+      <ul style="text-align: left; display: inline-block;">
+        <li><a href="/health" style="color: #00ff88;">/health</a> - Health check</li>
+        <li><a href="/swagger/" style="color: #00ff88;">/swagger/</a> - API documentation</li>
+        <li><a href="/v1/" style="color: #00ff88;">/v1/</a> - API endpoints</li>
+      </ul>
+    </div>
   </body>
 </html>

--- a/container/internal/assets/dist/index.html
+++ b/container/internal/assets/dist/index.html
@@ -1,81 +1,16 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/favicon@2x.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Catnip - Frontend Not Built</title>
-    <style>
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        margin: 0;
-        padding: 2rem;
-        background: #1a1a1a;
-        color: #ffffff;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .container {
-        text-align: center;
-        max-width: 600px;
-      }
-      h1 {
-        color: #ff6b6b;
-        margin-bottom: 1rem;
-      }
-      p {
-        line-height: 1.6;
-        margin-bottom: 1rem;
-        color: #cccccc;
-      }
-      .code {
-        background: #2a2a2a;
-        padding: 1rem;
-        border-radius: 8px;
-        font-family: 'Monaco', 'Menlo', monospace;
-        margin: 1rem 0;
-        color: #00ff88;
-      }
-      .warning {
-        background: #3a2a00;
-        border: 1px solid #ff9900;
-        border-radius: 8px;
-        padding: 1rem;
-        margin: 1rem 0;
-      }
-    </style>
+    <meta name="theme-color" content="#000000" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Catnip</title>
+    <script type="module" crossorigin src="/assets/index-DIOoOkzz.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CXhe8UEv.css">
   </head>
   <body>
-    <div class="container">
-      <h1>⚠️ Frontend Assets Not Built</h1>
-      
-      <div class="warning">
-        <p><strong>Development Mode:</strong> The frontend assets haven't been built yet.</p>
-      </div>
-      
-      <p>This is a placeholder page served from embedded fallback assets. To get the full Catnip frontend:</p>
-      
-      <div class="code">
-        # Build frontend assets<br>
-        pnpm build
-      </div>
-      
-      <p>Or run in development mode with Vite:</p>
-      
-      <div class="code">
-        # Start frontend dev server<br>
-        pnpm dev
-      </div>
-      
-      <p>Then restart the Go server to pick up the assets.</p>
-      
-      <p><strong>API is still available:</strong></p>
-      <ul style="text-align: left; display: inline-block;">
-        <li><a href="/health" style="color: #00ff88;">/health</a> - Health check</li>
-        <li><a href="/swagger/" style="color: #00ff88;">/swagger/</a> - API documentation</li>
-        <li><a href="/v1/" style="color: #00ff88;">/v1/</a> - API endpoints</li>
-      </ul>
-    </div>
+    <div id="root"></div>
   </body>
 </html>

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -2292,7 +2292,7 @@ func (s *GitService) CreateFromTemplate(templateID, projectName string) (*models
 	repoID := fmt.Sprintf("local/%s", projectName)
 
 	// Check if repository already exists in our state
-	if existingRepo, exists := s.stateManager.GetRepository(repoID); exists {
+	if _, exists := s.stateManager.GetRepository(repoID); exists {
 		return nil, nil, fmt.Errorf("project %s already exists", projectName)
 	}
 

--- a/docs/LOCAL_REPOSITORIES.md
+++ b/docs/LOCAL_REPOSITORIES.md
@@ -23,6 +23,7 @@ Catnip supports working with local Git repositories that are mounted into the co
 ### Worktree Creation
 
 When checking out a local repository:
+
 - No cloning occurs (unlike GitHub repos)
 - Worktrees are created directly from the mounted repository
 - The `handleLocalRepoWorktree()` function manages this process
@@ -31,12 +32,14 @@ When checking out a local repository:
 ## Key Files
 
 ### Backend
-- `container/internal/services/git.go`: 
+
+- `container/internal/services/git.go`:
   - `detectLocalRepos()`: Scans `/live/` for Git repositories
   - `handleLocalRepoWorktree()`: Creates worktrees for local repos
   - `ListGitHubRepositories()`: Includes local repos in the response
 
 ### Frontend
+
 - `src/routes/git.tsx`: `handleCheckout()` function routes `local/` prefixed repos correctly
 - `src/components/RepoSelector.tsx`: Displays local repos with appropriate labels
 
@@ -49,6 +52,7 @@ When checking out a local repository:
 ## Configuration
 
 Local repositories are automatically detected if:
+
 1. A directory exists in `/live/`
 2. The directory contains a `.git` folder
 3. The container has read/write access to the directory
@@ -56,12 +60,15 @@ Local repositories are automatically detected if:
 ## Debugging
 
 Common issues:
+
 - **Repository not detected**: Check if `/live/{repo_name}/.git` exists and has proper permissions
 - **Checkout fails**: Ensure the repository ID uses the `local/` prefix
 - **Worktree creation fails**: Verify the base repository is a valid Git repository
 
 ### Logging
+
 Look for these log messages:
+
 - `🔍 Detected local repository at /live/{name}`
 - `✅ Local repository loaded: local/{name}`
 - `📦 Checkout request: local/{name}`
@@ -101,7 +108,55 @@ Local repositories support a "Preview" feature that allows you to view changes o
 - **Backend Function**: `CreateWorktreePreview()` in `git.go`
 - **Helper Functions**: `hasUncommittedChanges()` and `createTemporaryCommit()`
 
-## Example Workflow
+## Template-Created Repositories
+
+In addition to mounted local repositories, Catnip can create new repositories from templates using the `CreateFromTemplate` function. These template-created repositories use a persistent bare repository approach.
+
+### How Template Repositories Work
+
+1. **Template Creation**: When creating from a template (e.g., React, Vue, Next.js):
+   - Template files are generated in a temporary directory
+   - A regular git repository is initialized and committed
+   - The temporary repo is cloned as a bare repository to `/volume/repos/{name}.git`
+
+2. **Persistent Storage**: Unlike mounted repos in `/live/`, template repositories are stored in `/volume/repos/` which persists across container restarts
+
+3. **Bare Repository Pattern**: Template repositories use the same architecture as remote GitHub repositories:
+   - Bare repository at `/volume/repos/{name}.git`
+   - Repository ID format: `local/{name}`
+   - Worktrees created in `/workspace/{name}/{session}/`
+
+### Key Differences from Mounted Repositories
+
+| Aspect                | Mounted (`/live/`)                    | Template-Created (`/volume/repos/`)  |
+| --------------------- | ------------------------------------- | ------------------------------------ |
+| **Storage**           | External mount, disappears on restart | Persistent volume, survives restarts |
+| **Repository Type**   | Regular git repository                | Bare git repository                  |
+| **Creation Method**   | Pre-existing, detected on startup     | Created via `CreateFromTemplate()`   |
+| **Worktree Handling** | Direct worktree from mounted repo     | Worktree from bare repository        |
+
+### Template Repository API
+
+- `POST /v1/git/templates/create`: Creates a new repository from a template
+- **Function**: `CreateFromTemplate()` in `git.go`
+- **Supported Templates**: `react-vite`, `vue-vite`, `nextjs-app`, `node-express`, `python-fastapi`
+
+### Implementation Details
+
+The `CreateFromTemplate` function follows this process:
+
+1. **Validation**: Checks if project name is valid and doesn't already exist
+2. **Template Setup**: Creates template files in temporary directory
+3. **Git Initialization**: Initializes git repo, adds files, makes initial commit
+4. **Bare Clone**: Clones temporary repo as bare repository to persistent location
+5. **Repository Registration**: Creates `Repository` object pointing to bare repo
+6. **Worktree Creation**: Creates initial worktree for immediate development
+
+This approach ensures template projects work identically to GitHub repositories and persist across container restarts.
+
+## Example Workflows
+
+### Mounted Repository Workflow
 
 1. Mount a Git repository to `/live/myproject`
 2. Start Catnip container
@@ -110,3 +165,13 @@ Local repositories support a "Preview" feature that allows you to view changes o
 5. Work in the worktree at `/workspace/myproject/{session_name}`
 6. Use "Preview" to create a branch with your changes in the main repository
 7. Changes can be merged back to the main repository using the "Merge to Main" feature
+
+### Template Repository Workflow
+
+1. Create a new project from template via UI or API
+2. Template repository is created at `/volume/repos/myproject.git`
+3. Repository appears as `local/myproject` in the UI
+4. Initial worktree is automatically created for development
+5. Work in the worktree at `/workspace/myproject/{session_name}`
+6. Project persists across container restarts
+7. Additional worktrees can be created as needed


### PR DESCRIPTION
## Summary

Refactored the `CreateFromTemplate` function to create bare repositories in `/volume/repos/` instead of regular repositories in `/live/`, ensuring template-created projects persist across container restarts.

## Changes

- **Persistent Storage**: Template repositories are now created as bare repositories at `/volume/repos/{name}.git` instead of `/live/{name}`, which disappears on container restart
- **Consistent Architecture**: Template projects now follow the same pattern as remote GitHub repositories - bare repo with worktrees, enabling full git operations and multiple worktree support
- **Documentation**: Added comprehensive documentation in `LOCAL_REPOSITORIES.md` explaining the new template repository system and how it differs from mounted repositories

## Implementation Notes

The new approach creates templates in a temporary directory, initializes git, then clones as a bare repository to the persistent location. This ensures template projects work identically to GitHub repositories while surviving container restarts, solving the issue where projects in `/live/` would be lost.