### PR TITLE
Replace workspace tooltip with popover including delete action

### DIFF
--- a/src/components/WorkspaceLeftSidebar.tsx
+++ b/src/components/WorkspaceLeftSidebar.tsx
@@ -600,6 +600,57 @@ export function WorkspaceLeftSidebar() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Single Workspace Delete Confirmation Dialog */}
+      <AlertDialog
+        open={singleWorkspaceDeleteDialog.open}
+        onOpenChange={(open) =>
+          setSingleWorkspaceDeleteDialog({
+            ...singleWorkspaceDeleteDialog,
+            open,
+          })
+        }
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Workspace</AlertDialogTitle>
+            <AlertDialogDescription>
+              {(() => {
+                const changesList = [];
+                if (singleWorkspaceDeleteDialog.hasChanges)
+                  changesList.push("uncommitted changes");
+                if (singleWorkspaceDeleteDialog.commitCount > 0)
+                  changesList.push(
+                    `${singleWorkspaceDeleteDialog.commitCount} commits`,
+                  );
+
+                return changesList.length > 0 ? (
+                  <>
+                    Delete workspace "{singleWorkspaceDeleteDialog.worktreeName}
+                    "? This workspace has{" "}
+                    <strong>{changesList.join(" and ")}</strong>. This action
+                    cannot be undone.
+                  </>
+                ) : (
+                  <>
+                    Delete workspace "{singleWorkspaceDeleteDialog.worktreeName}
+                    "? This action cannot be undone.
+                  </>
+                );
+              })()}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleSingleWorkspaceDeleteConfirmed}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete Workspace
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Replaced the tooltip on workspace items in the left sidebar with an interactive popover that provides better functionality and improved UX.

## Changes

- **Popover instead of tooltip**: Workspace branch names now open a popover on click instead of showing a tooltip on hover
- **Full branch name display**: The popover shows the complete, untruncated branch name along with the workspace name
- **Inline delete action**: Added a trash icon button within the popover that allows users to delete individual workspaces directly from the sidebar
- **Consistent delete logic**: The delete functionality reuses the same confirmation dialog and logic from the workspace actions menu, including warnings for uncommitted changes and unpushed commits

## Why

The previous tooltip only showed the branch name on hover and still truncated long names. The new popover provides a more accessible way to view full branch information and manage workspaces without needing to navigate to the workspace actions menu in the right sidebar.