### PR TITLE
Auto-navigate to workspace after creation

### DIFF
--- a/src/hooks/useGitApi.ts
+++ b/src/hooks/useGitApi.ts
@@ -161,7 +161,7 @@ export function useGitApi() {
     org: string,
     repo: string,
     branch: string = "main",
-  ): Promise<boolean> => {
+  ): Promise<{ success: boolean; worktreeName?: string }> => {
     setCheckoutLoading(true);
     try {
       // Build URL with optional branch query parameter
@@ -178,18 +178,23 @@ export function useGitApi() {
       });
 
       if (response.ok) {
+        const data = await response.json();
         // New worktree will be added to store via SSE events
         toast.success(`Successfully checked out ${org}/${repo}:${branch}`);
-        return true;
+        // Return success with the worktree name for navigation
+        return {
+          success: true,
+          worktreeName: data.worktree?.name,
+        };
       } else {
         const errorData = await response.json();
         toast.error(`Failed to checkout: ${errorData.error}`);
-        return false;
+        return { success: false };
       }
     } catch (error) {
       console.error("Checkout failed:", error);
       toast.error("Checkout failed");
-      return false;
+      return { success: false };
     } finally {
       setCheckoutLoading(false);
     }


### PR DESCRIPTION
## Summary

Users are now automatically navigated to their newly created workspace after successful repository checkout. Previously, the workspace creation dialog would close but leave users on the same page, requiring manual navigation to find their new workspace.

## Changes

- Updated `checkoutRepository` API hook to return worktree name from backend response
- Modified `NewWorkspaceDialog` to navigate to `/workspace/{repoId}/{workspaceName}` on successful creation
- Backend already provided the necessary worktree information in checkout response

## Implementation

The solution leverages the existing API response structure which already includes worktree details, eliminating the need for additional backend changes. Navigation uses the worktree name returned by the checkout endpoint for immediate redirection.