### PR TITLE
Add notifications settings toggle with persistent storage

### DIFF
--- a/container/docs/docs.go
+++ b/container/docs/docs.go
@@ -259,7 +259,7 @@ const docTemplate = `{
                 }
             },
             "put": {
-                "description": "Updates Claude Code configuration settings (currently only theme is supported)",
+                "description": "Updates Claude Code configuration settings (theme and notifications)",
                 "consumes": [
                     "application/json"
                 ],
@@ -1645,6 +1645,11 @@ const docTemplate = `{
                     "type": "boolean",
                     "example": true
                 },
+                "notificationsEnabled": {
+                    "description": "Whether notifications are enabled",
+                    "type": "boolean",
+                    "example": true
+                },
                 "numStartups": {
                     "description": "Number of times Claude has been started",
                     "type": "integer",
@@ -1674,6 +1679,11 @@ const docTemplate = `{
             "description": "Request to update Claude Code settings",
             "type": "object",
             "properties": {
+                "notificationsEnabled": {
+                    "description": "Whether notifications should be enabled",
+                    "type": "boolean",
+                    "example": true
+                },
                 "theme": {
                     "description": "Theme to set (must be one of the valid theme values)",
                     "type": "string",

--- a/container/docs/swagger.json
+++ b/container/docs/swagger.json
@@ -256,7 +256,7 @@
                 }
             },
             "put": {
-                "description": "Updates Claude Code configuration settings (currently only theme is supported)",
+                "description": "Updates Claude Code configuration settings (theme and notifications)",
                 "consumes": [
                     "application/json"
                 ],
@@ -1642,6 +1642,11 @@
                     "type": "boolean",
                     "example": true
                 },
+                "notificationsEnabled": {
+                    "description": "Whether notifications are enabled",
+                    "type": "boolean",
+                    "example": true
+                },
                 "numStartups": {
                     "description": "Number of times Claude has been started",
                     "type": "integer",
@@ -1671,6 +1676,11 @@
             "description": "Request to update Claude Code settings",
             "type": "object",
             "properties": {
+                "notificationsEnabled": {
+                    "description": "Whether notifications should be enabled",
+                    "type": "boolean",
+                    "example": true
+                },
                 "theme": {
                     "description": "Theme to set (must be one of the valid theme values)",
                     "type": "string",

--- a/container/docs/swagger.yaml
+++ b/container/docs/swagger.yaml
@@ -133,6 +133,10 @@ definitions:
         description: Whether user is authenticated (has userID)
         example: true
         type: boolean
+      notificationsEnabled:
+        description: Whether notifications are enabled
+        example: true
+        type: boolean
       numStartups:
         description: Number of times Claude has been started
         example: 15
@@ -156,6 +160,10 @@ definitions:
   github_com_vanpelt_catnip_internal_models.ClaudeSettingsUpdateRequest:
     description: Request to update Claude Code settings
     properties:
+      notificationsEnabled:
+        description: Whether notifications should be enabled
+        example: true
+        type: boolean
       theme:
         description: Theme to set (must be one of the valid theme values)
         enum:
@@ -1141,8 +1149,7 @@ paths:
     put:
       consumes:
       - application/json
-      description: Updates Claude Code configuration settings (currently only theme
-        is supported)
+      description: Updates Claude Code configuration settings (theme and notifications)
       parameters:
       - description: Settings update request
         in: body

--- a/container/internal/handlers/claude.go
+++ b/container/internal/handlers/claude.go
@@ -229,9 +229,9 @@ func (h *ClaudeHandler) GetClaudeSettings(c *fiber.Ctx) error {
 	return c.JSON(settings)
 }
 
-// UpdateClaudeSettings updates Claude configuration settings in ~/.claude.json
+// UpdateClaudeSettings updates Claude configuration settings in ~/.claude.json and volume settings.json
 // @Summary Update Claude settings
-// @Description Updates Claude Code configuration settings (currently only theme is supported)
+// @Description Updates Claude Code configuration settings (theme and notifications)
 // @Tags claude
 // @Accept json
 // @Produce json
@@ -248,18 +248,27 @@ func (h *ClaudeHandler) UpdateClaudeSettings(c *fiber.Ctx) error {
 		})
 	}
 
-	// Validate theme
-	validThemes := []string{"dark", "light", "dark-daltonized", "light-daltonized", "dark-ansi", "light-ansi"}
-	valid := false
-	for _, theme := range validThemes {
-		if req.Theme == theme {
-			valid = true
-			break
+	// Validate theme if provided
+	if req.Theme != "" {
+		validThemes := []string{"dark", "light", "dark-daltonized", "light-daltonized", "dark-ansi", "light-ansi"}
+		valid := false
+		for _, theme := range validThemes {
+			if req.Theme == theme {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return c.Status(400).JSON(fiber.Map{
+				"error": "Invalid theme value. Must be one of: dark, light, dark-daltonized, light-daltonized, dark-ansi, light-ansi",
+			})
 		}
 	}
-	if !valid {
+
+	// Validate that at least one field is provided
+	if req.Theme == "" && req.NotificationsEnabled == nil {
 		return c.Status(400).JSON(fiber.Map{
-			"error": "Invalid theme value. Must be one of: dark, light, dark-daltonized, light-daltonized, dark-ansi, light-ansi",
+			"error": "At least one setting must be provided (theme or notificationsEnabled)",
 		})
 	}
 

--- a/container/internal/models/claude.go
+++ b/container/internal/models/claude.go
@@ -182,13 +182,17 @@ type ClaudeSettings struct {
 	HasCompletedOnboarding bool `json:"hasCompletedOnboarding" example:"true"`
 	// Number of times Claude has been started
 	NumStartups int `json:"numStartups" example:"15"`
+	// Whether notifications are enabled
+	NotificationsEnabled bool `json:"notificationsEnabled" example:"true"`
 }
 
 // ClaudeSettingsUpdateRequest represents a request to update Claude settings
 // @Description Request to update Claude Code settings
 type ClaudeSettingsUpdateRequest struct {
 	// Theme to set (must be one of the valid theme values)
-	Theme string `json:"theme" example:"dark" enums:"dark,light,dark-daltonized,light-daltonized,dark-ansi,light-ansi"`
+	Theme string `json:"theme,omitempty" example:"dark" enums:"dark,light,dark-daltonized,light-daltonized,dark-ansi,light-ansi"`
+	// Whether notifications should be enabled
+	NotificationsEnabled *bool `json:"notificationsEnabled,omitempty" example:"true"`
 }
 
 // ClaudeHookEvent represents a hook event from Claude Code

--- a/container/internal/services/claude.go
+++ b/container/internal/services/claude.go
@@ -894,7 +894,7 @@ func (s *ClaudeService) CreateStreamingCompletion(ctx context.Context, req *mode
 	return err
 }
 
-// GetClaudeSettings reads Claude configuration settings from ~/.claude.json
+// GetClaudeSettings reads Claude configuration settings from ~/.claude.json and volume settings.json
 func (s *ClaudeService) GetClaudeSettings() (*models.ClaudeSettings, error) {
 	data, err := os.ReadFile(s.claudeConfigPath)
 	if err != nil {
@@ -906,6 +906,7 @@ func (s *ClaudeService) GetClaudeSettings() (*models.ClaudeSettings, error) {
 				Version:                "",
 				HasCompletedOnboarding: false,
 				NumStartups:            0,
+				NotificationsEnabled:   true, // Default to enabled
 			}, nil
 		}
 		return nil, fmt.Errorf("failed to read claude config file: %w", err)
@@ -922,6 +923,7 @@ func (s *ClaudeService) GetClaudeSettings() (*models.ClaudeSettings, error) {
 		Version:                "",
 		HasCompletedOnboarding: false,
 		NumStartups:            0,
+		NotificationsEnabled:   true, // Default to enabled
 	}
 
 	// Extract theme (default to "dark" if not set)
@@ -957,6 +959,12 @@ func (s *ClaudeService) GetClaudeSettings() (*models.ClaudeSettings, error) {
 		if startupsFloat, ok := startups.(float64); ok {
 			settings.NumStartups = int(startupsFloat)
 		}
+	}
+
+	// Read notifications setting from volume settings.json
+	notificationsEnabled, err := s.getNotificationsEnabled()
+	if err == nil {
+		settings.NotificationsEnabled = notificationsEnabled
 	}
 
 	return settings, nil

--- a/container/internal/services/claude.go
+++ b/container/internal/services/claude.go
@@ -108,6 +108,7 @@ func NewClaudeServiceWithWrapper(wrapper ClaudeSubprocessInterface) *ClaudeServi
 		claudeConfigPath:     filepath.Join(homeDir, ".claude.json"),
 		claudeProjectsDir:    filepath.Join(homeDir, ".claude", "projects"),
 		volumeProjectsDir:    filepath.Join(volumeDir, ".claude", ".claude", "projects"),
+		settingsPath:         filepath.Join(volumeDir, "settings.json"),
 		subprocessWrapper:    wrapper,
 		lastActivity:         make(map[string]time.Time),
 		lastUserPromptSubmit: make(map[string]time.Time),

--- a/container/internal/services/claude.go
+++ b/container/internal/services/claude.go
@@ -24,6 +24,7 @@ type ClaudeService struct {
 	claudeConfigPath  string
 	claudeProjectsDir string
 	volumeProjectsDir string
+	settingsPath      string // Path to volume settings.json
 	subprocessWrapper ClaudeSubprocessInterface
 	// Activity tracking for PTY sessions
 	activityMutex sync.RWMutex
@@ -89,6 +90,7 @@ func NewClaudeService() *ClaudeService {
 		claudeConfigPath:     filepath.Join(homeDir, ".claude.json"),
 		claudeProjectsDir:    filepath.Join(homeDir, ".claude", "projects"),
 		volumeProjectsDir:    filepath.Join(volumeDir, ".claude", ".claude", "projects"),
+		settingsPath:         filepath.Join(volumeDir, "settings.json"),
 		subprocessWrapper:    NewClaudeSubprocessWrapper(),
 		lastActivity:         make(map[string]time.Time),
 		lastUserPromptSubmit: make(map[string]time.Time),

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -742,19 +742,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                     </div>
                   </div>
                 </div>
-
-                <div className="p-4 border rounded-lg bg-blue-50 dark:bg-blue-950/20">
-                  <h4 className="font-medium mb-2 flex items-center gap-2 text-blue-700 dark:text-blue-300">
-                    <span>ℹ️</span>
-                    How It Works
-                  </h4>
-                  <ul className="text-sm space-y-1 text-blue-600 dark:text-blue-400">
-                    <li>• Notifications appear when Claude sessions end</li>
-                    <li>• Includes session title and current branch name</li>
-                    <li>• Shows your last active todo for context</li>
-                    <li>• Only appears when browser tab is in background</li>
-                  </ul>
-                </div>
               </div>
             </div>
           </div>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -174,17 +174,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     }
   }, [open, activeSection, catnipVersion]);
 
-  // Check notification support and permission status
-  React.useEffect(() => {
-    if (open && activeSection === "notifications") {
-      const isSupported = "Notification" in window;
-      setNotificationSupported(isSupported);
-      if (isSupported) {
-        setNotificationPermission(Notification.permission);
-      }
-    }
-  }, [open, activeSection]);
-
   // Function to update Claude theme setting
   const updateClaudeTheme = async (theme: string) => {
     setIsUpdatingClaudeSettings(true);
@@ -207,29 +196,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       console.error("Failed to update Claude settings:", error);
     } finally {
       setIsUpdatingClaudeSettings(false);
-    }
-  };
-
-  // Function to request notification permission
-  const requestNotificationPermission = async () => {
-    if (!notificationSupported) {
-      console.warn("Notifications are not supported in this browser");
-      return;
-    }
-
-    try {
-      const permission = await Notification.requestPermission();
-      setNotificationPermission(permission);
-
-      if (permission === "granted") {
-        // Show a test notification
-        new Notification("Notifications Enabled", {
-          body: "You'll now receive notifications when Claude sessions end.",
-          icon: "/favicon.png",
-        });
-      }
-    } catch (error) {
-      console.error("Failed to request notification permission:", error);
     }
   };
 
@@ -740,7 +706,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                         <Button
                           variant="default"
                           size="sm"
-                          onClick={requestNotificationPermission}
+                          onClick={requestBrowserPermission}
                         >
                           Enable Notifications
                         </Button>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -731,9 +731,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                         className="w-6 h-6 rounded"
                       />
                       <div>
-                        <p className="font-medium text-sm">
-                          Fix authentication bug (feature/auth-fix)
-                        </p>
+                        <p className="font-medium text-sm">feature/auth-fix</p>
                         <p className="text-xs text-muted-foreground">
                           Session ended - Last todo: Update password validation
                           logic

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -57,6 +57,7 @@ interface ClaudeSettings {
   version?: string;
   hasCompletedOnboarding: boolean;
   numStartups: number;
+  notificationsEnabled: boolean;
 }
 
 interface GitHubAuthStatus {
@@ -129,11 +130,13 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     }
   }, [activeSection, swaggerData]);
 
-  // Fetch Claude settings when component mounts or when switching to authentication/appearance
+  // Fetch Claude settings when component mounts or when switching to authentication/appearance/notifications
   React.useEffect(() => {
     if (
       open &&
-      (activeSection === "authentication" || activeSection === "appearance") &&
+      (activeSection === "authentication" ||
+        activeSection === "appearance" ||
+        activeSection === "notifications") &&
       !claudeSettings
     ) {
       fetch("/v1/claude/settings")

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -38,6 +38,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { useNotifications } from "@/lib/useNotifications";
 
 const settingsNav = [
   { name: "Authentication", icon: Key, id: "authentication" },
@@ -113,10 +114,11 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     React.useState<GitHubAuthStatus | null>(null);
   const [catnipVersion, setCatnipVersion] =
     React.useState<CatnipVersion | null>(null);
-  const [notificationPermission, setNotificationPermission] =
-    React.useState<NotificationPermission>("default");
-  const [notificationSupported, setNotificationSupported] =
-    React.useState(false);
+  const {
+    permission: notificationPermission,
+    isSupported: notificationSupported,
+    requestBrowserPermission,
+  } = useNotifications();
 
   // Fetch swagger data when component mounts
   React.useEffect(() => {

--- a/src/lib/useNotifications.ts
+++ b/src/lib/useNotifications.ts
@@ -97,15 +97,33 @@ export function useNotifications() {
       return null; // Native notification was sent
     }
 
-    // Fallback to browser notification
+    // Native notification failed, fall back to browser notification
     if (!isSupported) {
-      throw new Error("Notifications are not supported in this browser");
+      console.warn("Notifications are not supported in this browser");
+      return null;
     }
 
+    // If we don't have permission, request it first
     if (permission !== "granted") {
-      throw new Error("Notification permission not granted");
+      console.log(
+        "Browser notification permission not granted, requesting permission...",
+      );
+      try {
+        const newPermission = await requestPermission();
+        if (newPermission !== "granted") {
+          console.warn("Browser notification permission denied");
+          return null;
+        }
+      } catch (error) {
+        console.error(
+          "Failed to request browser notification permission:",
+          error,
+        );
+        return null;
+      }
     }
 
+    // Show browser notification
     return new Notification(title, options);
   };
 

--- a/src/lib/useNotifications.ts
+++ b/src/lib/useNotifications.ts
@@ -50,6 +50,29 @@ export function useNotifications() {
     }
   };
 
+  // For explicit permission requests (e.g., from settings UI)
+  const requestBrowserPermission =
+    async (): Promise<NotificationPermission> => {
+      if (!isSupported) {
+        throw new Error("Notifications are not supported in this browser");
+      }
+
+      try {
+        const result = await requestPermission();
+        if (result === "granted") {
+          // Show a test notification
+          new Notification("Notifications Enabled", {
+            body: "You'll now receive notifications when Claude sessions end.",
+            icon: "/favicon.png",
+          });
+        }
+        return result;
+      } catch (error) {
+        console.error("Failed to request notification permission:", error);
+        throw error;
+      }
+    };
+
   const sendNativeNotification = async (
     payload: NotificationPayload,
   ): Promise<boolean> => {
@@ -132,6 +155,7 @@ export function useNotifications() {
     isSupported,
     notificationsEnabled,
     requestPermission,
+    requestBrowserPermission,
     showNotification,
     sendNativeNotification,
     canShowNotifications: notificationsEnabled,

--- a/src/lib/useNotifications.ts
+++ b/src/lib/useNotifications.ts
@@ -116,7 +116,6 @@ export function useNotifications() {
     requestPermission,
     showNotification,
     sendNativeNotification,
-    canShowNotifications:
-      isSupported && permission === "granted" && notificationsEnabled,
+    canShowNotifications: notificationsEnabled,
   };
 }


### PR DESCRIPTION
## Summary

Adds a toggle switch in the settings dialog to enable/disable notifications, replacing the previous browser alert approach. The setting is persisted to `$VolumeDir/settings.json` and defaults to enabled.

## Changes

- **Backend**: Added `notificationsEnabled` field to `ClaudeSettings` model with persistent storage in volume settings.json
- **Frontend**: Replaced "Disable" button with toggle switch in notifications settings, updated `useNotifications` hook to respect the setting
- **UX Improvements**: Simplified notification permission flow to only request browser permissions when native notifications fail, removed "How It Works" section, and streamlined notification preview

## Implementation Notes

The `canShowNotifications` property now only checks the user's preference setting, while permission handling is done automatically during notification display. This provides a cleaner user experience with native-first notifications and graceful browser fallback.