### PR TITLE
Fix workspace redirect URL parsing in NewWorkspaceDialog

### DIFF
--- a/src/components/NewWorkspaceDialog.tsx
+++ b/src/components/NewWorkspaceDialog.tsx
@@ -215,14 +215,17 @@ export function NewWorkspaceDialog({
 
         // Navigate to the newly created workspace
         if (result.worktreeName) {
-          // Navigate to /workspace/project/workspace
-          void navigate({
-            to: "/workspace/$project/$workspace",
-            params: {
-              project: repoId,
-              workspace: result.worktreeName,
-            },
-          });
+          // Split the worktree name (format: "projectName/workspaceName")
+          const parts = result.worktreeName.split("/");
+          if (parts.length >= 2) {
+            void navigate({
+              to: "/workspace/$project/$workspace",
+              params: {
+                project: parts[0],
+                workspace: parts[1],
+              },
+            });
+          }
         }
       } else {
         setError(

--- a/src/components/NewWorkspaceDialog.tsx
+++ b/src/components/NewWorkspaceDialog.tsx
@@ -178,13 +178,11 @@ export function NewWorkspaceDialog({
     setError(null);
     try {
       let result: { success: boolean; worktreeName?: string };
-      let repoId: string;
 
       // Check if this is a local repository (starts with "local/")
       if (url.startsWith("local/")) {
         // For local repos, extract the repo name
         const repoName = url.split("/")[1];
-        repoId = `local/${repoName}`;
         result = await checkoutRepository("local", repoName, branch);
       } else {
         // For GitHub URLs, parse the org and repo name
@@ -200,7 +198,6 @@ export function NewWorkspaceDialog({
         if (match) {
           const org = match[1];
           const repo = match[2];
-          repoId = `${org}/${repo}`;
           result = await checkoutRepository(org, repo, branch);
         } else {
           setError(

--- a/src/components/NewWorkspaceDialog.tsx
+++ b/src/components/NewWorkspaceDialog.tsx
@@ -219,7 +219,7 @@ export function NewWorkspaceDialog({
           void navigate({
             to: "/workspace/$project/$workspace",
             params: {
-              project: repoId.replace("/", "_"),
+              project: repoId,
               workspace: result.worktreeName,
             },
           });


### PR DESCRIPTION
## Summary

Fixed incorrect URL generation when redirecting to newly created workspaces. The dialog was incorrectly using `repoId` as the project parameter and the full `worktreeName` as the workspace parameter, resulting in malformed URLs like `/workspace/local_catnip/catnip%2Fchip`.

## Changes

Updated the navigation logic to properly parse the `worktreeName` by splitting on "/" and using the first part as the project name and the second part as the workspace name. This ensures correct URLs like `/workspace/catnip/chip`.

The fix handles the case where `worktreeName` follows the format "projectName/workspaceName" and extracts the appropriate values for URL routing.