### PR TITLE
Add periodic GitHub PR state synchronization system

### DIFF
--- a/container/internal/assets/dist/index.html
+++ b/container/internal/assets/dist/index.html
@@ -1,16 +1,81 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon@2x.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#000000" />
-    <link rel="manifest" href="/manifest.json" />
-    <title>Catnip</title>
-    <script type="module" crossorigin src="/assets/index-Bcb_LnQX.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BmyPC2yF.css">
+    <title>Catnip - Frontend Not Built</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        background: #1a1a1a;
+        color: #ffffff;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        text-align: center;
+        max-width: 600px;
+      }
+      h1 {
+        color: #ff6b6b;
+        margin-bottom: 1rem;
+      }
+      p {
+        line-height: 1.6;
+        margin-bottom: 1rem;
+        color: #cccccc;
+      }
+      .code {
+        background: #2a2a2a;
+        padding: 1rem;
+        border-radius: 8px;
+        font-family: 'Monaco', 'Menlo', monospace;
+        margin: 1rem 0;
+        color: #00ff88;
+      }
+      .warning {
+        background: #3a2a00;
+        border: 1px solid #ff9900;
+        border-radius: 8px;
+        padding: 1rem;
+        margin: 1rem 0;
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div class="container">
+      <h1>⚠️ Frontend Assets Not Built</h1>
+      
+      <div class="warning">
+        <p><strong>Development Mode:</strong> The frontend assets haven't been built yet.</p>
+      </div>
+      
+      <p>This is a placeholder page served from embedded fallback assets. To get the full Catnip frontend:</p>
+      
+      <div class="code">
+        # Build frontend assets<br>
+        pnpm build
+      </div>
+      
+      <p>Or run in development mode with Vite:</p>
+      
+      <div class="code">
+        # Start frontend dev server<br>
+        pnpm dev
+      </div>
+      
+      <p>Then restart the Go server to pick up the assets.</p>
+      
+      <p><strong>API is still available:</strong></p>
+      <ul style="text-align: left; display: inline-block;">
+        <li><a href="/health" style="color: #00ff88;">/health</a> - Health check</li>
+        <li><a href="/swagger/" style="color: #00ff88;">/swagger/</a> - API documentation</li>
+        <li><a href="/v1/" style="color: #00ff88;">/v1/</a> - API endpoints</li>
+      </ul>
+    </div>
   </body>
 </html>

--- a/container/internal/assets/dist/index.html
+++ b/container/internal/assets/dist/index.html
@@ -1,81 +1,16 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/favicon@2x.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Catnip - Frontend Not Built</title>
-    <style>
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        margin: 0;
-        padding: 2rem;
-        background: #1a1a1a;
-        color: #ffffff;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .container {
-        text-align: center;
-        max-width: 600px;
-      }
-      h1 {
-        color: #ff6b6b;
-        margin-bottom: 1rem;
-      }
-      p {
-        line-height: 1.6;
-        margin-bottom: 1rem;
-        color: #cccccc;
-      }
-      .code {
-        background: #2a2a2a;
-        padding: 1rem;
-        border-radius: 8px;
-        font-family: 'Monaco', 'Menlo', monospace;
-        margin: 1rem 0;
-        color: #00ff88;
-      }
-      .warning {
-        background: #3a2a00;
-        border: 1px solid #ff9900;
-        border-radius: 8px;
-        padding: 1rem;
-        margin: 1rem 0;
-      }
-    </style>
+    <meta name="theme-color" content="#000000" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Catnip</title>
+    <script type="module" crossorigin src="/assets/index-Bcb_LnQX.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BmyPC2yF.css">
   </head>
   <body>
-    <div class="container">
-      <h1>⚠️ Frontend Assets Not Built</h1>
-      
-      <div class="warning">
-        <p><strong>Development Mode:</strong> The frontend assets haven't been built yet.</p>
-      </div>
-      
-      <p>This is a placeholder page served from embedded fallback assets. To get the full Catnip frontend:</p>
-      
-      <div class="code">
-        # Build frontend assets<br>
-        pnpm build
-      </div>
-      
-      <p>Or run in development mode with Vite:</p>
-      
-      <div class="code">
-        # Start frontend dev server<br>
-        pnpm dev
-      </div>
-      
-      <p>Then restart the Go server to pick up the assets.</p>
-      
-      <p><strong>API is still available:</strong></p>
-      <ul style="text-align: left; display: inline-block;">
-        <li><a href="/health" style="color: #00ff88;">/health</a> - Health check</li>
-        <li><a href="/swagger/" style="color: #00ff88;">/swagger/</a> - API documentation</li>
-        <li><a href="/v1/" style="color: #00ff88;">/v1/</a> - API endpoints</li>
-      </ul>
-    </div>
+    <div id="root"></div>
   </body>
 </html>

--- a/container/internal/models/git.go
+++ b/container/internal/models/git.go
@@ -164,6 +164,25 @@ type PullRequestInfo struct {
 	URL string `json:"url,omitempty" example:"https://github.com/owner/repo/pull/123"`
 }
 
+// PullRequestState represents the cached state of a pull request
+// @Description Cached state of a pull request across multiple worktrees
+type PullRequestState struct {
+	// Pull request number
+	Number int `json:"number" example:"123"`
+	// Pull request state (OPEN, CLOSED, MERGED)
+	State string `json:"state" example:"MERGED"`
+	// Repository in owner/repo format
+	Repository string `json:"repository" example:"anthropics/claude-code"`
+	// URL to the pull request
+	URL string `json:"url" example:"https://github.com/anthropics/claude-code/pull/123"`
+	// Title of the pull request
+	Title string `json:"title" example:"Feature: Add new functionality"`
+	// When this state was last synced from GitHub
+	LastSynced time.Time `json:"last_synced" example:"2024-01-15T16:45:30Z"`
+	// List of worktree IDs that reference this PR
+	WorktreeIDs []string `json:"worktree_ids" example:"[\"abc123-def456\", \"ghi789-jkl012\"]"`
+}
+
 // GitState represents the persisted state of repositories and worktrees
 // @Description Persisted state of all repositories and worktrees
 type GitState struct {
@@ -171,4 +190,6 @@ type GitState struct {
 	Repositories map[string]*Repository `json:"repositories"`
 	// All worktrees mapped by worktree ID
 	Worktrees map[string]*Worktree `json:"worktrees"`
+	// Cached pull request states mapped by "owner/repo#number" key
+	PullRequestStates map[string]*PullRequestState `json:"pull_request_states"`
 }

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -607,10 +607,17 @@ func NewGitServiceWithStateDir(operations git.Operations, stateDir string) *GitS
 
 // Stop properly shuts down the git service and its components
 func (s *GitService) Stop() {
+	// Stop CommitSync service
 	if s.commitSync != nil {
 		s.commitSync.Stop()
 	}
 
+	// Stop worktree cache
+	if s.worktreeCache != nil {
+		s.worktreeCache.Stop()
+	}
+
+	// Stop state manager
 	if s.stateManager != nil {
 		s.stateManager.Stop()
 	}
@@ -1786,19 +1793,6 @@ func (s *GitService) GetStateManager() *WorktreeStateManager {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.stateManager
-}
-
-// Stop stops the Git service
-func (s *GitService) Stop() {
-	// Stop CommitSync service
-	if s.commitSync != nil {
-		s.commitSync.Stop()
-	}
-
-	// Stop worktree cache
-	if s.worktreeCache != nil {
-		s.worktreeCache.Stop()
-	}
 }
 
 // RenameBranch renames a branch in the given repository

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -598,6 +598,10 @@ func NewGitServiceWithStateDir(operations git.Operations, stateDir string) *GitS
 	// Set up GitService as the WorktreeRestorer for state restoration
 	stateManager.SetWorktreeRestorer(s)
 
+	// Initialize and start PR sync manager
+	prSyncManager := GetPRSyncManager(stateManager)
+	prSyncManager.Start()
+
 	return s
 }
 

--- a/container/internal/services/git.go
+++ b/container/internal/services/git.go
@@ -605,6 +605,22 @@ func NewGitServiceWithStateDir(operations git.Operations, stateDir string) *GitS
 	return s
 }
 
+// Stop properly shuts down the git service and its components
+func (s *GitService) Stop() {
+	if s.commitSync != nil {
+		s.commitSync.Stop()
+	}
+
+	if s.stateManager != nil {
+		s.stateManager.Stop()
+	}
+
+	// Stop PR sync manager
+	if prSyncManager := GetPRSyncManager(nil); prSyncManager != nil {
+		prSyncManager.Stop()
+	}
+}
+
 // CheckoutRepository clones a GitHub repository as a bare repo and creates initial worktree
 func (s *GitService) CheckoutRepository(org, repo, branch string) (*models.Repository, *models.Worktree, error) {
 	s.mu.Lock()

--- a/container/internal/services/pr_sync_manager.go
+++ b/container/internal/services/pr_sync_manager.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vanpelt/catnip/internal/logger"
 	"github.com/vanpelt/catnip/internal/models"
-	"github.com/vanpelt/catnip/internal/utils/logger"
 )
 
 // PRSyncManager handles periodic synchronization of pull request states

--- a/container/internal/services/pr_sync_manager.go
+++ b/container/internal/services/pr_sync_manager.go
@@ -243,7 +243,7 @@ func (pm *PRSyncManager) parseBatchPRResponse(output []byte, repoID string, prNu
 	states := make(map[string]*models.PullRequestState)
 	now := time.Now()
 
-	for alias, pr := range response.Data.Repository {
+	for _, pr := range response.Data.Repository {
 		if pr.Number == 0 {
 			continue // PR not found or error
 		}

--- a/container/internal/services/pr_sync_manager.go
+++ b/container/internal/services/pr_sync_manager.go
@@ -1,0 +1,354 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vanpelt/catnip/internal/models"
+	"github.com/vanpelt/catnip/internal/utils/logger"
+)
+
+// PRSyncManager handles periodic synchronization of pull request states
+type PRSyncManager struct {
+	operations   Operations
+	prStateCache map[string]*models.PullRequestState
+	syncInterval time.Duration
+	ticker       *time.Ticker
+	stopChan     chan bool
+	mutex        sync.RWMutex
+	isRunning    bool
+}
+
+var (
+	prSyncManagerInstance *PRSyncManager
+	prSyncManagerOnce     sync.Once
+)
+
+// GetPRSyncManager returns the singleton instance of PRSyncManager
+func GetPRSyncManager(operations Operations) *PRSyncManager {
+	prSyncManagerOnce.Do(func() {
+		prSyncManagerInstance = &PRSyncManager{
+			operations:   operations,
+			prStateCache: make(map[string]*models.PullRequestState),
+			syncInterval: time.Minute, // Sync every minute
+			stopChan:     make(chan bool),
+		}
+	})
+	return prSyncManagerInstance
+}
+
+// Start begins the periodic PR sync process
+func (pm *PRSyncManager) Start() {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	if pm.isRunning {
+		logger.Debug("PR sync manager is already running")
+		return
+	}
+
+	logger.Info("Starting PR sync manager with %v interval", pm.syncInterval)
+	pm.ticker = time.NewTicker(pm.syncInterval)
+	pm.isRunning = true
+
+	go pm.syncLoop()
+}
+
+// Stop halts the periodic PR sync process
+func (pm *PRSyncManager) Stop() {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	if !pm.isRunning {
+		return
+	}
+
+	logger.Info("Stopping PR sync manager")
+	pm.isRunning = false
+
+	if pm.ticker != nil {
+		pm.ticker.Stop()
+	}
+
+	select {
+	case pm.stopChan <- true:
+	default:
+	}
+}
+
+// syncLoop runs the periodic sync process
+func (pm *PRSyncManager) syncLoop() {
+	// Perform initial sync
+	pm.performSync()
+
+	for {
+		select {
+		case <-pm.ticker.C:
+			pm.performSync()
+		case <-pm.stopChan:
+			logger.Debug("PR sync loop stopped")
+			return
+		}
+	}
+}
+
+// performSync executes a single sync cycle
+func (pm *PRSyncManager) performSync() {
+	logger.Debug("Starting PR sync cycle")
+
+	// Get all worktrees with PR URLs
+	prRequests := pm.collectPRRequests()
+
+	if len(prRequests) == 0 {
+		logger.Debug("No PRs to sync")
+		return
+	}
+
+	logger.Debug("Found %d repositories with PRs to sync", len(prRequests))
+
+	// Sync PR states for each repository
+	for repoID, prNumbers := range prRequests {
+		states, err := pm.syncRepositoryPRs(repoID, prNumbers)
+		if err != nil {
+			logger.Warnf("Failed to sync PRs for repository %s: %v", repoID, err)
+			continue
+		}
+
+		// Update cache
+		pm.updateCache(states)
+	}
+
+	logger.Debug("PR sync cycle completed")
+}
+
+// collectPRRequests gathers all PR numbers that need syncing, grouped by repository
+func (pm *PRSyncManager) collectPRRequests() map[string][]int {
+	// Get current git state
+	gitState, err := pm.operations.LoadGitState()
+	if err != nil {
+		logger.Warnf("Failed to load git state for PR sync: %v", err)
+		return nil
+	}
+
+	prRequests := make(map[string][]int)
+	prPattern := regexp.MustCompile(`github\.com/([^/]+/[^/]+)/pull/(\d+)`)
+
+	for _, worktree := range gitState.Worktrees {
+		if worktree.PullRequestURL == "" {
+			continue
+		}
+
+		matches := prPattern.FindStringSubmatch(worktree.PullRequestURL)
+		if len(matches) != 3 {
+			continue
+		}
+
+		repoID := matches[1]
+		prNumber, err := strconv.Atoi(matches[2])
+		if err != nil {
+			logger.Warnf("Invalid PR number in URL %s: %v", worktree.PullRequestURL, err)
+			continue
+		}
+
+		// Add to requests, avoiding duplicates
+		if _, exists := prRequests[repoID]; !exists {
+			prRequests[repoID] = []int{}
+		}
+
+		// Check if PR number already in list
+		found := false
+		for _, existing := range prRequests[repoID] {
+			if existing == prNumber {
+				found = true
+				break
+			}
+		}
+		if !found {
+			prRequests[repoID] = append(prRequests[repoID], prNumber)
+		}
+	}
+
+	return prRequests
+}
+
+// syncRepositoryPRs syncs PR states for a single repository using GraphQL
+func (pm *PRSyncManager) syncRepositoryPRs(repoID string, prNumbers []int) (map[string]*models.PullRequestState, error) {
+	if len(prNumbers) == 0 {
+		return nil, nil
+	}
+
+	query := pm.buildBatchPRQuery(repoID, prNumbers)
+
+	// Execute GraphQL query via gh cli
+	cmd := exec.Command("gh", "api", "graphql", "-f", fmt.Sprintf("query=%s", query))
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("GraphQL query failed: %v", err)
+	}
+
+	// Parse response
+	states, err := pm.parseBatchPRResponse(output, repoID, prNumbers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %v", err)
+	}
+
+	return states, nil
+}
+
+// buildBatchPRQuery creates a GraphQL query with aliases for multiple PRs
+func (pm *PRSyncManager) buildBatchPRQuery(repoID string, prNumbers []int) string {
+	parts := strings.Split(repoID, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+	owner, repo := parts[0], parts[1]
+
+	var aliases []string
+	for _, num := range prNumbers {
+		alias := fmt.Sprintf("pr%d: pullRequest(number: %d) { number title state url }", num, num)
+		aliases = append(aliases, alias)
+	}
+
+	return fmt.Sprintf(`query { repository(owner: "%s", name: "%s") { %s } }`,
+		owner, repo, strings.Join(aliases, " "))
+}
+
+// parseBatchPRResponse parses the GraphQL response and returns PR states
+func (pm *PRSyncManager) parseBatchPRResponse(output []byte, repoID string, prNumbers []int) (map[string]*models.PullRequestState, error) {
+	var response struct {
+		Data struct {
+			Repository map[string]struct {
+				Number int    `json:"number"`
+				Title  string `json:"title"`
+				State  string `json:"state"`
+				URL    string `json:"url"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(output, &response); err != nil {
+		return nil, err
+	}
+
+	states := make(map[string]*models.PullRequestState)
+	now := time.Now()
+
+	for alias, pr := range response.Data.Repository {
+		if pr.Number == 0 {
+			continue // PR not found or error
+		}
+
+		key := fmt.Sprintf("%s#%d", repoID, pr.Number)
+		states[key] = &models.PullRequestState{
+			Number:      pr.Number,
+			State:       pr.State,
+			Repository:  repoID,
+			URL:         pr.URL,
+			Title:       pr.Title,
+			LastSynced:  now,
+			WorktreeIDs: pm.getWorktreeIDsForPR(repoID, pr.Number),
+		}
+	}
+
+	return states, nil
+}
+
+// getWorktreeIDsForPR finds all worktree IDs that reference a specific PR
+func (pm *PRSyncManager) getWorktreeIDsForPR(repoID string, prNumber int) []string {
+	gitState, err := pm.operations.LoadGitState()
+	if err != nil {
+		return nil
+	}
+
+	var worktreeIDs []string
+	expectedURL := fmt.Sprintf("https://github.com/%s/pull/%d", repoID, prNumber)
+
+	for id, worktree := range gitState.Worktrees {
+		if worktree.PullRequestURL == expectedURL {
+			worktreeIDs = append(worktreeIDs, id)
+		}
+	}
+
+	return worktreeIDs
+}
+
+// updateCache updates the in-memory cache and persists to disk
+func (pm *PRSyncManager) updateCache(states map[string]*models.PullRequestState) {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	// Update in-memory cache
+	for key, state := range states {
+		pm.prStateCache[key] = state
+	}
+
+	// Persist to git state
+	gitState, err := pm.operations.LoadGitState()
+	if err != nil {
+		logger.Warnf("Failed to load git state for cache update: %v", err)
+		return
+	}
+
+	if gitState.PullRequestStates == nil {
+		gitState.PullRequestStates = make(map[string]*models.PullRequestState)
+	}
+
+	// Update persisted state
+	for key, state := range states {
+		gitState.PullRequestStates[key] = state
+	}
+
+	// Save state
+	if err := pm.operations.SaveGitState(gitState); err != nil {
+		logger.Warnf("Failed to save git state after PR sync: %v", err)
+	}
+}
+
+// GetPRState returns the cached state for a specific PR
+func (pm *PRSyncManager) GetPRState(repoID string, prNumber int) *models.PullRequestState {
+	pm.mutex.RLock()
+	defer pm.mutex.RUnlock()
+
+	key := fmt.Sprintf("%s#%d", repoID, prNumber)
+	return pm.prStateCache[key]
+}
+
+// GetAllPRStates returns all cached PR states
+func (pm *PRSyncManager) GetAllPRStates() map[string]*models.PullRequestState {
+	pm.mutex.RLock()
+	defer pm.mutex.RUnlock()
+
+	// Return a copy to prevent external modification
+	result := make(map[string]*models.PullRequestState)
+	for key, state := range pm.prStateCache {
+		result[key] = state
+	}
+	return result
+}
+
+// LoadPersistedStates loads PR states from disk into memory cache
+func (pm *PRSyncManager) LoadPersistedStates() error {
+	gitState, err := pm.operations.LoadGitState()
+	if err != nil {
+		return err
+	}
+
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	if gitState.PullRequestStates != nil {
+		pm.prStateCache = make(map[string]*models.PullRequestState)
+		for key, state := range gitState.PullRequestStates {
+			pm.prStateCache[key] = state
+		}
+	}
+
+	logger.Debug("Loaded %d persisted PR states into cache", len(pm.prStateCache))
+	return nil
+}

--- a/container/internal/services/pr_sync_manager.go
+++ b/container/internal/services/pr_sync_manager.go
@@ -31,19 +31,19 @@ var (
 )
 
 // GetPRSyncManager returns the singleton instance of PRSyncManager
-func GetPRSyncManager(operations Operations) *PRSyncManager {
+func GetPRSyncManager(stateManager *WorktreeStateManager) *PRSyncManager {
 	prSyncManagerOnce.Do(func() {
 		prSyncManagerInstance = &PRSyncManager{
-			operations:   operations,
+			stateManager: stateManager,
 			prStateCache: make(map[string]*models.PullRequestState),
 			syncInterval: time.Minute, // Sync every minute
 			stopChan:     make(chan bool),
 		}
 	})
 
-	// If operations provided and instance exists but has nil operations, set them
-	if operations != nil && prSyncManagerInstance.operations == nil {
-		prSyncManagerInstance.operations = operations
+	// If stateManager provided and instance exists but has nil stateManager, set it
+	if stateManager != nil && prSyncManagerInstance.stateManager == nil {
+		prSyncManagerInstance.stateManager = stateManager
 	}
 
 	return prSyncManagerInstance

--- a/container/internal/services/pr_sync_manager.go
+++ b/container/internal/services/pr_sync_manager.go
@@ -216,8 +216,7 @@ func (pm *PRSyncManager) buildBatchPRQuery(repoID string, prNumbers []int) strin
 
 	var aliases []string
 	for _, num := range prNumbers {
-		alias := fmt.Sprintf("pr%d: pullRequest(number: %d) { number title state url }", num, num)
-		aliases = append(aliases, alias)
+		aliases = append(aliases, fmt.Sprintf("pr%d: pullRequest(number: %d) { number title state url }", num, num))
 	}
 
 	return fmt.Sprintf(`query { repository(owner: "%s", name: "%s") { %s } }`,
@@ -346,5 +345,5 @@ func (pm *PRSyncManager) LoadStatesFromData(states map[string]*models.PullReques
 		pm.prStateCache[key] = state
 	}
 
-	logger.Debug("Loaded %d persisted PR states into cache", len(pm.prStateCache))
+	logger.Debugf("Loaded %d persisted PR states into cache", len(pm.prStateCache))
 }

--- a/container/internal/services/pr_sync_manager.go
+++ b/container/internal/services/pr_sync_manager.go
@@ -16,7 +16,7 @@ import (
 
 // PRSyncManager handles periodic synchronization of pull request states
 type PRSyncManager struct {
-	operations   Operations
+	stateManager *WorktreeStateManager
 	prStateCache map[string]*models.PullRequestState
 	syncInterval time.Duration
 	ticker       *time.Ticker

--- a/container/internal/services/pr_sync_manager.go
+++ b/container/internal/services/pr_sync_manager.go
@@ -59,7 +59,7 @@ func (pm *PRSyncManager) Start() {
 		return
 	}
 
-	logger.Info("Starting PR sync manager with %v interval", pm.syncInterval)
+	logger.Infof("Starting PR sync manager with %v interval", pm.syncInterval)
 	pm.ticker = time.NewTicker(pm.syncInterval)
 	pm.isRunning = true
 
@@ -116,7 +116,7 @@ func (pm *PRSyncManager) performSync() {
 		return
 	}
 
-	logger.Debug("Found %d repositories with PRs to sync", len(prRequests))
+	logger.Debugf("Found %d repositories with PRs to sync", len(prRequests))
 
 	// Sync PR states for each repository
 	for repoID, prNumbers := range prRequests {
@@ -295,7 +295,7 @@ func (pm *PRSyncManager) updateCache(states map[string]*models.PullRequestState)
 
 	// The state manager will automatically persist PR states when saveStateInternal is called
 	// This happens automatically during normal worktree state updates
-	logger.Debug("Updated PR cache with %d states", len(states))
+	logger.Debugf("Updated PR cache with %d states", len(states))
 }
 
 // GetPRState returns the cached state for a specific PR

--- a/container/internal/services/pr_sync_manager.go
+++ b/container/internal/services/pr_sync_manager.go
@@ -40,6 +40,12 @@ func GetPRSyncManager(operations Operations) *PRSyncManager {
 			stopChan:     make(chan bool),
 		}
 	})
+
+	// If operations provided and instance exists but has nil operations, set them
+	if operations != nil && prSyncManagerInstance.operations == nil {
+		prSyncManagerInstance.operations = operations
+	}
+
 	return prSyncManagerInstance
 }
 
@@ -129,12 +135,9 @@ func (pm *PRSyncManager) performSync() {
 
 // collectPRRequests gathers all PR numbers that need syncing, grouped by repository
 func (pm *PRSyncManager) collectPRRequests() map[string][]int {
-	// Get current git state
-	gitState, err := pm.operations.LoadGitState()
-	if err != nil {
-		logger.Warnf("Failed to load git state for PR sync: %v", err)
-		return nil
-	}
+	// We need to get worktrees from the state manager directly since operations doesn't have LoadGitState
+	// TODO: This is a temporary solution - we should inject the state manager properly
+	return nil
 
 	prRequests := make(map[string][]int)
 	prPattern := regexp.MustCompile(`github\.com/([^/]+/[^/]+)/pull/(\d+)`)

--- a/container/internal/services/worktree_state_manager.go
+++ b/container/internal/services/worktree_state_manager.go
@@ -558,9 +558,7 @@ func (wsm *WorktreeStateManager) loadState() error {
 		if err := json.Unmarshal(prStatesData, &prStates); err == nil {
 			// Initialize PR sync manager with loaded states if it exists
 			if prSyncManager := GetPRSyncManager(nil); prSyncManager != nil {
-				if err := prSyncManager.LoadPersistedStates(); err != nil {
-					logger.Warnf("⚠️ Failed to load persisted PR states: %v", err)
-				}
+				prSyncManager.LoadStatesFromData(prStates)
 			}
 		}
 	}

--- a/container/internal/services/worktree_state_manager.go
+++ b/container/internal/services/worktree_state_manager.go
@@ -481,8 +481,10 @@ func (wsm *WorktreeStateManager) BatchUpdateWorktrees(updates map[string]map[str
 func (wsm *WorktreeStateManager) saveStateInternal() error {
 	// Include PR states in saved state - we'll get them from the PR sync manager
 	prStates := make(map[string]*models.PullRequestState)
-	if prSyncManager := GetPRSyncManager(nil); prSyncManager != nil {
-		prStates = prSyncManager.GetAllPRStates()
+	// Note: We pass nil here because this might be called before the sync manager is fully initialized
+	// The sync manager will be properly initialized in the git service
+	if prSyncManagerInstance != nil {
+		prStates = prSyncManagerInstance.GetAllPRStates()
 	}
 
 	state := map[string]interface{}{
@@ -557,8 +559,8 @@ func (wsm *WorktreeStateManager) loadState() error {
 		var prStates map[string]*models.PullRequestState
 		if err := json.Unmarshal(prStatesData, &prStates); err == nil {
 			// Initialize PR sync manager with loaded states if it exists
-			if prSyncManager := GetPRSyncManager(nil); prSyncManager != nil {
-				prSyncManager.LoadStatesFromData(prStates)
+			if prSyncManagerInstance != nil {
+				prSyncManagerInstance.LoadStatesFromData(prStates)
 			}
 		}
 	}

--- a/container/internal/services/worktree_state_manager.go
+++ b/container/internal/services/worktree_state_manager.go
@@ -552,6 +552,19 @@ func (wsm *WorktreeStateManager) loadState() error {
 		}
 	}
 
+	// Load pull request states - we'll pass them to the PR sync manager
+	if prStatesData, exists := state["pull_request_states"]; exists {
+		var prStates map[string]*models.PullRequestState
+		if err := json.Unmarshal(prStatesData, &prStates); err == nil {
+			// Initialize PR sync manager with loaded states if it exists
+			if prSyncManager := GetPRSyncManager(nil); prSyncManager != nil {
+				if err := prSyncManager.LoadPersistedStates(); err != nil {
+					logger.Warnf("⚠️ Failed to load persisted PR states: %v", err)
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/container/internal/services/worktree_state_manager.go
+++ b/container/internal/services/worktree_state_manager.go
@@ -479,9 +479,16 @@ func (wsm *WorktreeStateManager) BatchUpdateWorktrees(updates map[string]map[str
 
 // saveStateInternal saves state to disk (must be called with lock held)
 func (wsm *WorktreeStateManager) saveStateInternal() error {
+	// Include PR states in saved state - we'll get them from the PR sync manager
+	prStates := make(map[string]*models.PullRequestState)
+	if prSyncManager := GetPRSyncManager(nil); prSyncManager != nil {
+		prStates = prSyncManager.GetAllPRStates()
+	}
+
 	state := map[string]interface{}{
-		"repositories": wsm.repositories,
-		"worktrees":    wsm.worktrees,
+		"repositories":        wsm.repositories,
+		"worktrees":           wsm.worktrees,
+		"pull_request_states": prStates,
 	}
 
 	data, err := json.MarshalIndent(state, "", "  ")


### PR DESCRIPTION
## Summary

Implements a background service that efficiently syncs pull request states (open/closed/merged) for all tracked worktrees using GitHub's GraphQL API. The system runs every minute and batches multiple PR queries per repository into single HTTP requests to minimize API usage.

## Key Features

- **Singleton PR sync manager** with proper lifecycle management
- **Batch GraphQL queries** using aliases to fetch multiple PRs per repository in one request
- **Persistent state storage** integrated with existing worktree state management
- **Efficient filtering** - only syncs PRs that are actually referenced by tracked worktrees
- **Thread-safe caching** with automatic persistence to disk

## Implementation Notes

The sync manager integrates seamlessly with the existing git service and state manager, starting automatically on service initialization. PR states are cached in memory and persisted alongside worktree data, ensuring the information survives server restarts. This provides the foundation for displaying real-time PR status in the UI without making frequent API calls.