### PR TITLE
Add URL support to macOS native notifications with workspace links

### DIFF
--- a/container/docs/docs.go
+++ b/container/docs/docs.go
@@ -2660,6 +2660,9 @@ const docTemplate = `{
                 },
                 "title": {
                     "type": "string"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/container/docs/swagger.json
+++ b/container/docs/swagger.json
@@ -2657,6 +2657,9 @@
                 },
                 "title": {
                     "type": "string"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/container/docs/swagger.yaml
+++ b/container/docs/swagger.yaml
@@ -905,6 +905,8 @@ definitions:
         type: string
       title:
         type: string
+      url:
+        type: string
     type: object
   internal_handlers.SSEMessage:
     properties:

--- a/container/internal/cmd/notify.go
+++ b/container/internal/cmd/notify.go
@@ -49,7 +49,7 @@ Send a basic notification:
 
 		fmt.Printf("📢 Sending notification: %s\n", title)
 
-		err := tui.SendNativeNotification(title, body, subtitle)
+		err := tui.SendNativeNotification(title, body, subtitle, "")
 		if err != nil {
 			fmt.Printf("❌ Failed to send notification: %v\n", err)
 			return

--- a/container/internal/handlers/claude.go
+++ b/container/internal/handlers/claude.go
@@ -425,10 +425,7 @@ func (h *ClaudeHandler) HandleClaudeHook(c *fiber.Ctx) error {
 				logger.Debugf("🔔 Emitting notification event: %s", title)
 
 				// Generate workspace URL - remove /workspace prefix if present
-				workspacePath := workspaceDir
-				if strings.HasPrefix(workspacePath, "/workspace") {
-					workspacePath = workspacePath[10:] // Remove "/workspace"
-				}
+				workspacePath := strings.TrimPrefix(workspaceDir, "/workspace")
 				workspaceURL := fmt.Sprintf("http://localhost:8080/workspace%s", workspacePath)
 
 				h.eventsHandler.broadcastEvent(AppEvent{

--- a/container/internal/handlers/claude.go
+++ b/container/internal/handlers/claude.go
@@ -424,8 +424,12 @@ func (h *ClaudeHandler) HandleClaudeHook(c *fiber.Ctx) error {
 			if settings, err := h.claudeService.GetClaudeSettings(); err == nil && settings.NotificationsEnabled {
 				logger.Debugf("🔔 Emitting notification event: %s", title)
 
-				// Generate workspace URL
-				workspaceURL := fmt.Sprintf("http://localhost:8080/workspace%s", workspaceDir)
+				// Generate workspace URL - remove /workspace prefix if present
+				workspacePath := workspaceDir
+				if strings.HasPrefix(workspacePath, "/workspace") {
+					workspacePath = workspacePath[10:] // Remove "/workspace"
+				}
+				workspaceURL := fmt.Sprintf("http://localhost:8080/workspace%s", workspacePath)
 
 				h.eventsHandler.broadcastEvent(AppEvent{
 					Type: NotificationEvent,

--- a/container/internal/handlers/claude.go
+++ b/container/internal/handlers/claude.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"

--- a/container/internal/handlers/claude.go
+++ b/container/internal/handlers/claude.go
@@ -422,12 +422,17 @@ func (h *ClaudeHandler) HandleClaudeHook(c *fiber.Ctx) error {
 			// Also emit a notification event directly via SSE if notifications are enabled
 			if settings, err := h.claudeService.GetClaudeSettings(); err == nil && settings.NotificationsEnabled {
 				logger.Debugf("🔔 Emitting notification event: %s", title)
+
+				// Generate workspace URL
+				workspaceURL := fmt.Sprintf("http://localhost:8080/workspace%s", workspaceDir)
+
 				h.eventsHandler.broadcastEvent(AppEvent{
 					Type: NotificationEvent,
 					Payload: NotificationPayload{
 						Title:    title,
 						Body:     description,
 						Subtitle: "", // Leave empty for consistency with existing notification structure
+						URL:      workspaceURL,
 					},
 				})
 			} else if err != nil {

--- a/container/internal/handlers/notifications.go
+++ b/container/internal/handlers/notifications.go
@@ -12,6 +12,7 @@ type NotificationPayload struct {
 	Title    string `json:"title"`
 	Body     string `json:"body"`
 	Subtitle string `json:"subtitle,omitempty"`
+	URL      string `json:"url,omitempty"`
 }
 
 // NotificationHandler handles notification requests

--- a/container/internal/handlers/notifications.go
+++ b/container/internal/handlers/notifications.go
@@ -61,6 +61,7 @@ func (h *NotificationHandler) HandleNotification(c *fiber.Ctx) error {
 			Title:    payload.Title,
 			Body:     payload.Body,
 			Subtitle: payload.Subtitle,
+			URL:      payload.URL,
 		},
 	})
 

--- a/container/internal/tui/notifications_darwin.go
+++ b/container/internal/tui/notifications_darwin.go
@@ -111,16 +111,18 @@ import (
 )
 
 // SendNativeNotification sends a native macOS notification using the clean, simple approach
-func SendNativeNotification(title, body, subtitle string) error {
+func SendNativeNotification(title, body, subtitle, url string) error {
 	cTitle := C.CString(title)
 	cBody := C.CString(body)
 	cSubtitle := C.CString(subtitle)
+	cURL := C.CString(url)
 
 	defer C.free(unsafe.Pointer(cTitle))
 	defer C.free(unsafe.Pointer(cBody))
 	defer C.free(unsafe.Pointer(cSubtitle))
+	defer C.free(unsafe.Pointer(cURL))
 
-	C.sendNotification(cTitle, cBody, cSubtitle)
+	C.sendNotification(cTitle, cBody, cSubtitle, cURL)
 	return nil
 }
 

--- a/container/internal/tui/notifications_darwin.go
+++ b/container/internal/tui/notifications_darwin.go
@@ -9,6 +9,26 @@ package tui
 #import <Foundation/Foundation.h>
 #import <Cocoa/Cocoa.h>
 
+@interface NotificationDelegate : NSObject <NSUserNotificationCenterDelegate>
+@end
+
+@implementation NotificationDelegate
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center shouldPresentNotification:(NSUserNotification *)notification {
+    return YES;
+}
+
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification {
+    if (notification.activationType == NSUserNotificationActivationTypeActionButtonClicked) {
+        NSString *url = notification.userInfo[@"url"];
+        if (url) {
+            [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
+        }
+    }
+}
+@end
+
+static NotificationDelegate *notificationDelegate = nil;
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
@@ -36,6 +56,12 @@ void sendNotification(const char* title, const char* body, const char* subtitle,
         if (!center) {
             NSLog(@"[Catnip] ERROR: Could not get NSUserNotificationCenter");
             return;
+        }
+
+        // Set up delegate for handling clicks (only once)
+        if (!notificationDelegate) {
+            notificationDelegate = [[NotificationDelegate alloc] init];
+            center.delegate = notificationDelegate;
         }
 
         NSUserNotification *notification = [[NSUserNotification alloc] init];

--- a/container/internal/tui/notifications_darwin.go
+++ b/container/internal/tui/notifications_darwin.go
@@ -13,7 +13,7 @@ package tui
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 // Clean, simple notification implementation based on terminal-notifier pattern
-void sendNotification(const char* title, const char* body, const char* subtitle) {
+void sendNotification(const char* title, const char* body, const char* subtitle, const char* url) {
     @autoreleasepool {
         // Debug: NSLog(@"[Catnip] Sending notification: %s", title);
 
@@ -44,6 +44,14 @@ void sendNotification(const char* title, const char* body, const char* subtitle)
 
         if (subtitle && strlen(subtitle) > 0) {
             notification.subtitle = [NSString stringWithUTF8String:subtitle];
+        }
+
+        // Add URL to userInfo if provided
+        if (url && strlen(url) > 0) {
+            NSString *urlString = [NSString stringWithUTF8String:url];
+            notification.userInfo = @{@"url": urlString};
+            notification.hasActionButton = YES;
+            notification.actionButtonTitle = @"Show";
         }
 
         notification.soundName = NSUserNotificationDefaultSoundName;

--- a/container/internal/tui/notifications_darwin.go
+++ b/container/internal/tui/notifications_darwin.go
@@ -72,13 +72,16 @@ void sendNotification(const char* title, const char* body, const char* subtitle,
             notification.subtitle = [NSString stringWithUTF8String:subtitle];
         }
 
-        // Add URL to userInfo if provided
+        // Add URL to userInfo - use default workspace URL if none provided
+        NSString *urlString;
         if (url && strlen(url) > 0) {
-            NSString *urlString = [NSString stringWithUTF8String:url];
-            notification.userInfo = @{@"url": urlString};
-            notification.hasActionButton = YES;
-            notification.actionButtonTitle = @"Show";
+            urlString = [NSString stringWithUTF8String:url];
+        } else {
+            urlString = @"http://localhost:8080/workspace";
         }
+        notification.userInfo = @{@"url": urlString};
+        notification.hasActionButton = YES;
+        notification.actionButtonTitle = @"Show";
 
         notification.soundName = NSUserNotificationDefaultSoundName;
 

--- a/container/internal/tui/notifications_other.go
+++ b/container/internal/tui/notifications_other.go
@@ -7,8 +7,8 @@ import (
 )
 
 // SendNativeNotification is a no-op on non-macOS platforms
-func SendNativeNotification(title, body, subtitle string) error {
-	debugLog("Notification (unsupported platform): %s - %s", title, body)
+func SendNativeNotification(title, body, subtitle, url string) error {
+	debugLog("Notification (unsupported platform): %s - %s (URL: %s)", title, body, url)
 	return fmt.Errorf("native notifications not supported on this platform")
 }
 

--- a/container/internal/tui/sse_client.go
+++ b/container/internal/tui/sse_client.go
@@ -275,6 +275,7 @@ func (c *SSEClient) processEvent(data string) {
 			title, _ := payload["title"].(string)
 			body, _ := payload["body"].(string)
 			subtitle, _ := payload["subtitle"].(string)
+			url, _ := payload["url"].(string)
 
 			// Send native notification if supported
 			if IsNotificationSupported() {
@@ -298,7 +299,7 @@ func (c *SSEClient) processEvent(data string) {
 				c.notificationHistory[title] = now
 				c.notificationHistoryMu.Unlock()
 
-				if err := SendNativeNotification(title, body, subtitle); err != nil {
+				if err := SendNativeNotification(title, body, subtitle, url); err != nil {
 					debugLog("TUI SSE: Failed to send notification: %v", err)
 				} else {
 					debugLog("TUI SSE: Sent notification: %s", title)


### PR DESCRIPTION
This PR enhances the macOS native notification system to support clickable URLs that open the relevant workspace in the browser.

## Changes
- Added a `URL` field to the `NotificationPayload` struct to support notification URLs
- Updated the macOS notification implementation to display a "Show" action button that opens the URL in the default browser
- Modified `HandleClaudeHook` to automatically generate workspace URLs (e.g., `http://localhost:8080/workspace/catnip/whisker`) for Claude activity notifications
- Added a notification delegate to handle action button clicks on macOS

## Implementation Notes
- The notification system now defaults to the general workspace URL when no specific URL is provided
- The implementation correctly handles the `/workspace` prefix to avoid URL duplication
- Non-macOS platforms gracefully handle the new URL parameter without breaking existing functionality