### PR TITLE
Fix missing github_repository field in expired codespace credentials

### DIFF
--- a/worker/codespace-store.ts
+++ b/worker/codespace-store.ts
@@ -5,6 +5,8 @@ interface CodespaceCredentials {
   githubUser: string;
   codespaceName: string;
   githubRepository?: string;
+  githubOrg?: string;
+  githubRepo?: string;
   createdAt: number;
   updatedAt: number;
 }
@@ -321,6 +323,7 @@ export class CodespaceStore extends DurableObject<Record<string, any>> {
               githubToken: "", // Empty token - will need to be refreshed
               githubUser: githubUser,
               codespaceName: row.codespace_name as string,
+              githubRepository: row.github_repository as string | undefined,
               createdAt: result.createdAt,
               updatedAt: result.updatedAt,
             };
@@ -344,6 +347,7 @@ export class CodespaceStore extends DurableObject<Record<string, any>> {
                 githubToken: "", // Empty token - will need to be refreshed
                 githubUser: githubUser,
                 codespaceName: credentials.codespaceName,
+                githubRepository: credentials.githubRepository,
                 createdAt: credentials.createdAt,
                 updatedAt: credentials.updatedAt,
               };
@@ -359,6 +363,7 @@ export class CodespaceStore extends DurableObject<Record<string, any>> {
               githubToken: "", // Empty token - will need to be refreshed
               githubUser: githubUser,
               codespaceName: row.codespace_name as string,
+              githubRepository: row.github_repository as string | undefined,
               createdAt: result.createdAt,
               updatedAt: result.updatedAt,
             };


### PR DESCRIPTION
## Problem

Older codespaces with expired credentials (>24 hours) were missing the `github_repository` field in API responses, even though the field existed in the database. This occurred because the code that creates "basic codespace" objects (when credentials are nullified after expiration) wasn't including the repository field from the database.

## Changes

- Added `githubOrg` and `githubRepo` fields to the `CodespaceCredentials` interface to ensure these fields are properly stored in encrypted data
- Fixed all three code paths that create basic codespace objects to include `githubRepository` from the database:
  - When credentials are already nullified
  - When credentials expire during retrieval
  - When decryption fails

## Impact

Codespaces with expired credentials now correctly return repository information in API responses, ensuring consistent data availability regardless of credential status.