### PR TITLE
Fix onboarding security notes detection on Linux

### DIFF
--- a/container/internal/services/claude_onboarding.go
+++ b/container/internal/services/claude_onboarding.go
@@ -477,7 +477,9 @@ func (s *ClaudeOnboardingService) detectState(output string) OnboardingState {
 	}
 
 	// SECURITY_NOTES: Security information screen (check after BYPASS_PERMISSIONS)
-	if containsPattern(cleanOutput, []string{"Security notes:", "security information", "important security"}) {
+	// Patterns include: header text, and content text which may appear without the header
+	// depending on terminal size and buffer state
+	if containsPattern(cleanOutput, []string{"Security notes:", "security information", "important security", "prompt injection risks"}) {
 		return StateSecurityNotes
 	}
 


### PR DESCRIPTION
Add "prompt injection risks" to StateSecurityNotes detection patterns. The security notes screen content may appear without the "Security notes:" header depending on terminal size and PTY buffer state, causing the state machine to get stuck at AUTH_CONFIRM on Linux CI.